### PR TITLE
Feat/pypi

### DIFF
--- a/evmlab/tools/opviewer.py
+++ b/evmlab/tools/opviewer.py
@@ -776,7 +776,7 @@ class EvmTrace(object):
     Main Wrapper class to handle Evm Traces
     """
 
-    def __init__(self, api="https://mainnet.infura.io/evmlab"):
+    def __init__(self, api="https://mainnet.infura.io/remix"):
 
         self.api = utils.getApi(api)
         self.source_path = None
@@ -1023,8 +1023,8 @@ python3 opviewer.py -f example.json -s /path/to/contracts -j /path/to/combined.j
 
     web3settings = parser.add_argument_group('Web3',
                                              'Settings about where to fetch information from when displaying contract sources (default infura)')
-    web3settings.add_argument("--web3", type=str, default="https://mainnet.infura.io/",
-                              help="Web3 API url to fetch info from (default 'https://mainnet.infura.io/'")
+    web3settings.add_argument("--web3", type=str, default="https://mainnet.infura.io/remix",
+                              help="Web3 API url to fetch info from (default 'https://mainnet.infura.io/remix'")
 
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python
+"""
+deps:
+*) pip install --upgrade pip wheel setuptools twine
+publish:
+1) #> python setup.py sdist bdist_wheel
+2) #> twine upload dist/*   #<specific specific wheel if needed>; --repository <testpypi> or  --repository-url <testpypi-url>
+"""
+import os
+from setuptools import setup
 
-from distutils.core import setup
 
-version = '0.1'
+def read(fname):
+    fpath = os.path.join(os.path.dirname(__file__), fname)
+    fd = open(fpath, 'r')
+    data = fd.read()
+    fd.close()
+    return data
+
+
+version = '0.3.1'  # keep this in sync with the last release tag!
 
 setup(name='Evmlab',
       version=version,
@@ -12,11 +28,15 @@ setup(name='Evmlab',
       license="GPLv3",
       keywords=["ethereum", "transaction", "debugger"],
       url="https://github.com/ethereum/evmlab/",
-      download_url="https://github.com/ethereum/evmlab/tarball/v%s"%version,
+      download_url="https://github.com/ethereum/evmlab/tarball/v%s" % version,
+      # generate rst from .md:  pandoc --from=markdown --to=rst README.md -o README.rst (fix diff section and footer)
+      long_description=read("README.md") if os.path.isfile("README.md") else "",
+      # for pypi.org; empty because we do not ship Readme.md with the package. may otherwise fail on install
+      long_description_content_type='text/markdown',  # requires twine and recent setuptools
       packages=['evmlab',
                 'evmlab.tools',
                 'evmlab.tools.reproducer'],
-      package_data={'evmlab.tools.reproducer':["templates/*"]},
+      package_data={'evmlab.tools.reproducer': ["templates/*"]},
       install_requires=["requests", "web3", "eth-hash[pycryptodome]", "rlp>=1.0"],
       extras_require={"consolegui": ["urwid"],
                       "abidecoder": ["ethereum-input-decoder"],


### PR DESCRIPTION
prepare evmlab for pypi and switch to new upload procedure (wheel) via twine.

1. please merge this PR
2. create a new evmlab tag/release v0.3.1
3. i will push it to pypi then. (https://pypi.org/project/Evmlab/)

fixes #55 