### PR TITLE
fuzzer: use shutil.move instead of os.rename

### DIFF
--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -4,7 +4,7 @@
 Executes state tests on multiple clients, checking for EVM trace equivalence
 
 """
-import json, sys, re, os, subprocess, io, itertools, traceback, time, collections
+import json, sys, re, os, subprocess, io, itertools, traceback, time, collections, shutil
 from contextlib import redirect_stderr, redirect_stdout
 
 from evmlab import vm as VMUtils
@@ -162,7 +162,7 @@ class StateTest():
         # Save the actual test json
         saveloc = "%s/%s" % (cfg.artefacts, self.filename())
         logger.info("Saving testcase as %s", saveloc)
-        os.rename(self.fullfilename() , saveloc)
+        shutil.move(self.fullfilename() , saveloc)
 
         newTracefiles = []
 
@@ -170,7 +170,7 @@ class StateTest():
             fname = os.path.basename(f)
             newloc = "%s/%s" % (cfg.artefacts,fname)
             logger.info("Saving trace as %s", newloc)
-            os.rename(f, newloc)
+            shutil.move(f, newloc)
             newTracefiles.append(newloc)
     
         self.traceFiles = newTracefiles


### PR DESCRIPTION
Fixes the following problem when temp is on a separate filesystem from where artefacts are stored:
```
Traceback (most recent call last):
  File "utilities/fuzzerweb.py", line 59, in <module>
    main()
  File "utilities/fuzzerweb.py", line 55, in main
    f.startFuzzing()
  File "/datadrive/evmlab/utilities/fuzzer.py", line 467, in startFuzzing
    __end_previous_test()
  File "/datadrive/evmlab/utilities/fuzzer.py", line 441, in __end_previous_test
    failingTestcase = processTraces(previous_test)
  File "/datadrive/evmlab/utilities/fuzzer.py", line 410, in processTraces
    test.saveArtefacts()
  File "/datadrive/evmlab/utilities/fuzzer.py", line 165, in saveArtefacts
    os.rename(self.fullfilename() , saveloc)
OSError: [Errno 18] Invalid cross-device link: '/datadrive/evmlabtemp/testfiles/DEFAULT-Wed_07_15_02-17565-1189-test.json' -> '/root/tmp/evmlab/artefacts/DEFAULT-Wed_07_15_02-17565-1189-test.json'

```