### PR TITLE
Fix/smart code generation dependency 

### DIFF
--- a/evmlab/tools/opviewer.py
+++ b/evmlab/tools/opviewer.py
@@ -545,7 +545,7 @@ class DebugViewer(object):
   > tx:       %s
   > input:    %s
   > decoded*: %s""" % (txhash,
-                      txinput,
+                      txinput[:100]+"..." if len(txinput)>100 else txinput,
                       txinput_decoded))
 
         top = DebugViewer.wrap(urwid.Pile([

--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -22,3 +22,4 @@ try:
 except ImportError as ie:
     RndCode = RndCodeBytes
     logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
+    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,13 @@ setup(name='Evmlab',
       long_description_content_type='text/markdown',  # requires twine and recent setuptools
       packages=find_packages(),
       package_data={'evmlab.tools.reproducer': ["templates/*"]},
-      install_requires=["requests", "web3", "eth-hash[pycryptodome]", "rlp>=1.0"],
+      install_requires=["requests",
+                        "web3",
+                        "eth-hash[pycryptodome]",
+                        "rlp>=1.0"],
       extras_require={"consolegui": ["urwid"],
                       "abidecoder": ["ethereum-input-decoder"],
-                      "docker": ["docker==3.0.0"]}
+                      "docker": ["docker==3.0.0"],
+                      "fuzztests": ["ethereum-dasm"],  # for smart evm-code generation
+                      }
       )


### PR DESCRIPTION
Added `ethereum-dasm` to **extra dependency** `fuzztests` required for smart-code generation. This extra dependency should list all depdendencies explicitly required for the fuzztests.

### local install

```
#> (.env3) tin@ubuntu1610:~/evmlab$ pip install -e ".[fuzztests]"
```

### once published to pypi (next release)

```
(.env3) tin@ubuntu1610:~/evmlab$ pip install "evmlab[fuzztests]"
```

If everything works out it should not show the following warning: `----> Falling back to Random Code Generation based on byte distribution!`