### PR TITLE
fix - do not generate random transaction values to avoid creating invalid transactions that attempt to spend more than the accounts balance

### DIFF
--- a/evmlab/tools/statetests/templates/object_based.py
+++ b/evmlab/tools/statetests/templates/object_based.py
@@ -82,7 +82,7 @@ TEMPLATE_RandomStateTest = {
             "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
             "to": rndval.RndDestAddress(),
             "value": [
-                rndval.RndHex32(),
+                #rndval.RndHex32(),
                 "0"
             ]
         }
@@ -157,7 +157,8 @@ OLD_TEMPLATE_RandomStateTest = {
             "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
             "to": rndval.RndDestAddress(),
             "value": [
-                rndval.RndHex32(),
+                "0"
+                #rndval.RndHex32(),
             ]
         }
     }


### PR DESCRIPTION
avoid creating invalid transactions by not generating random values for transactions or we might end up with lots of transactions sending more value than available in the account.

as per request @holiman / discord.

>(MHS) Should rather always be between zero and <whatever that account has in the prestate