### PR TITLE
More fixes

### DIFF
--- a/evmlab/opcodes.py
+++ b/evmlab/opcodes.py
@@ -80,7 +80,7 @@ opcodes = {
     0xf2: ['CALLCODE', 7, 1, 40],
     0xf3: ['RETURN', 2, 0, 0],
     0xf4: ['DELEGATECALL', 6, 0, 40],
-    0xf4: ['CREATE2', 4, 1, 32000],
+    0xf5: ['CREATE2', 4, 1, 32000],
     0xfa: ['STATICCALL', 6, 1, 40],
     0xfd: ['REVERT', 2, 0, 0],
     0xff: ['SUICIDE', 1, 0, 0],

--- a/evmlab/tools/opviewer.py
+++ b/evmlab/tools/opviewer.py
@@ -539,9 +539,9 @@ class DebugViewer(object):
             txinput_decoded = ethereum_input_decoder.AbiMethod.from_input_lookup(ethereum_input_decoder.Utils.str_to_bytes(txinput)) if ethereum_input_decoder else "<input decoder not installed>"
         except Exception as e:  # not going to import from eth_abi to not make the code depending on it
             txinput_decoded = "!! DecodingError: %s" %e
-
-
-        inp_view = urwid.Text("""
+        inp_view = urwid.Text("No transaction available")
+        if txhash is not None:
+            inp_view = urwid.Text("""
   > tx:       %s
   > input:    %s
   > decoded*: %s""" % (txhash,

--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -5,7 +5,7 @@
 #
 # https://github.com/ethereum/testeth/blob/ee0c6776c01b09045a379220c7e490000dae9377/test/tools/fuzzTesting/createRandomTest.cpp
 #
-from .address import RndAddress, RndAddressType, RndDestAddress, RndByteSequence
+from .address import RndAddress, RndAddressType, RndDestAddress, RndByteSequence,RndDestAddressOrZero
 from .bytes import RndByteSequence, Rnd0xHash32, RndHash20, RndHash32, RndV
 from .hexint import RndHex32, RndBlockGasLimit, RndGasPrice, RndTransactionGasLimit, RndHexInt
 from .rlp import RndRlp

--- a/evmlab/tools/statetests/rndval/address.py
+++ b/evmlab/tools/statetests/rndval/address.py
@@ -1,6 +1,7 @@
 import enum
 import random
 from .bytes import RndByteSequence
+from evmlab import decode_hex
 
 
 class RndAddressType(enum.Enum):
@@ -43,7 +44,7 @@ class RndAddress(RndByteSequence):
                                                         "0000000000000000000000000000000000000006",
                                                         "0000000000000000000000000000000000000007",
                                                         "0000000000000000000000000000000000000008"],
-                 RndAddressType.SPECIAL_CREATE: [None]}
+                 RndAddressType.SPECIAL_CREATE: ["0000000000000000000000000000000000000000"]}
 
     def __init__(self, seed=None, length=20, prefix="0x", _types=[RndAddressType.RANDOM]):
         super().__init__(seed=seed, length=length, prefix=prefix)
@@ -78,7 +79,6 @@ class RndAddress(RndByteSequence):
                 # pick from list
                 return self._get_rnd_address_from_list(self.addresses.get(_type))
             # otherwise fallthrough to multilist selection
-
         # todo: add probabilities
         types_set = set(self.types)
         if types_set.issubset([RndAddressType.PRECOMPILED, RndAddressType.STATE_ACCOUNT,
@@ -97,20 +97,35 @@ class RndAddress(RndByteSequence):
 
             # RANDOM
             if self.randomPercent()<probabilities["randomAddressProbability"]:
-                return super().generate()  # generate 20byte default random
+                a = super().generate()  # generate 20byte default random
+                return a
 
             # RETURN SENDERS address
             if self.randomPercent() < probabilities["sendingAddressProbability"]:
                 return self._get_rnd_address_from_list(self.addresses.get(RndAddressType.SENDING_ACCOUNT))
 
             # FALLBACK - state account
-            return self._get_rnd_address_from_list(self.addresses.get(RndAddressType.STATE_ACCOUNT))
-
+            a  = self._get_rnd_address_from_list(self.addresses.get(RndAddressType.STATE_ACCOUNT))
+            return a
         # RANDOM
         return super().generate()  # generate 20byte default random
 
+    def as_bytes(self):
+      data = self.generate()
+      if data != None:
+        return decode_hex(data[2:])
+       
 
 class RndDestAddress(RndAddress):
+
+    placeholder = "[DESTADDRESS]"
+
+    def __init__(self, seed=None, length=20, prefix="0x", _types=[RndAddressType.PRECOMPILED,
+                                                                  RndAddressType.STATE_ACCOUNT]):
+        super().__init__(seed=seed, length=length, prefix=prefix)
+        self.types = _types
+
+class RndDestAddressOrZero(RndAddress):
 
     placeholder = "[DESTADDRESS]"
 

--- a/evmlab/tools/statetests/rndval/address.py
+++ b/evmlab/tools/statetests/rndval/address.py
@@ -43,7 +43,7 @@ class RndAddress(RndByteSequence):
                                                         "0000000000000000000000000000000000000006",
                                                         "0000000000000000000000000000000000000007",
                                                         "0000000000000000000000000000000000000008"],
-                 RndAddressType.SPECIAL_CREATE: ["0000000000000000000000000000000000000000"]}
+                 RndAddressType.SPECIAL_CREATE: [None]}
 
     def __init__(self, seed=None, length=20, prefix="0x", _types=[RndAddressType.RANDOM]):
         super().__init__(seed=seed, length=length, prefix=prefix)
@@ -93,7 +93,7 @@ class RndAddress(RndByteSequence):
             #if types_set != set([RndAddressType.PRECOMPILED, RndAddressType.STATE_ACCOUNT]):
             if types_set.intersection([RndAddressType.SPECIAL_ALL, RndAddressType.SPECIAL_CREATE]):
                 if self.randomPercent()<probabilities["emptyAddressProbability"]:
-                    return self._get_rnd_address_from_list(self.addresses.get(RndAddressType.SPECIAL_CREATE))
+                    return ""
 
             # RANDOM
             if self.randomPercent()<probabilities["randomAddressProbability"]:
@@ -119,4 +119,3 @@ class RndDestAddress(RndAddress):
                                                                   RndAddressType.SPECIAL_CREATE]):
         super().__init__(seed=seed, length=length, prefix=prefix)
         self.types = _types
-

--- a/evmlab/tools/statetests/rndval/codesmart.py
+++ b/evmlab/tools/statetests/rndval/codesmart.py
@@ -82,8 +82,13 @@ opcodes = {
     0xff: ['SUICIDE', 1, 0, 0],
 }
 valid_opcodes = list(opcodes.keys())
+const_opcodes = [0x1b, #: ['SHL', 2, 1, 3],
+                    0x1c, #: ['SHR', 2, 1, 3],
+                    0x1d, #: ['SAR', 2, 1, 3],
+                    0xf4, #: ['CREATE2', 4, 1, 32000],
+                    0x3f] #: ['EXTCODEHASH', 1, 1, 400],
 
-
+constantinople_skewed_set = valid_opcodes + const_opcodes + const_opcodes  + const_opcodes 
 class RndCodeInstr(_RndCodeBase):
     """
     Random bytecode based on stat spread of instructions
@@ -110,7 +115,7 @@ class RndCodeInstr(_RndCodeBase):
         b = []
         for _ in range(length):
 #            b.append(valid_opcodes[random.randint(0,len(valid_opcodes)-1)])
-            b.append(random.choice(valid_opcodes))
+            b.append(random.choice(constantinople_skewed_set))
 
 #        for _ in range(128):
 #            b.append(rnd_prolog.random())

--- a/evmlab/tools/statetests/rndval/codesmart.py
+++ b/evmlab/tools/statetests/rndval/codesmart.py
@@ -4,6 +4,84 @@ from .code import _RndCodeBase
 from .address import RndAddress, RndDestAddress, RndAddressType
 
 import ethereum_dasm.asm.registry as asm_registry
+opcodes = {
+    0x00: ['STOP', 0, 0, 0],
+    0x01: ['ADD', 2, 1, 3],
+    0x02: ['MUL', 2, 1, 5],
+    0x03: ['SUB', 2, 1, 3],
+    0x04: ['DIV', 2, 1, 5],
+    0x05: ['SDIV', 2, 1, 5],
+    0x06: ['MOD', 2, 1, 5],
+    0x07: ['SMOD', 2, 1, 5],
+    0x08: ['ADDMOD', 3, 1, 8],
+    0x09: ['MULMOD', 3, 1, 8],
+    0x0a: ['EXP', 2, 1, 10],
+    0x0b: ['SIGNEXTEND', 2, 1, 5],
+    0x10: ['LT', 2, 1, 3],
+    0x11: ['GT', 2, 1, 3],
+    0x12: ['SLT', 2, 1, 3],
+    0x13: ['SGT', 2, 1, 3],
+    0x14: ['EQ', 2, 1, 3],
+    0x15: ['ISZERO', 1, 1, 3],
+    0x16: ['AND', 2, 1, 3],
+    0x17: ['OR', 2, 1, 3],
+    0x18: ['XOR', 2, 1, 3],
+    0x19: ['NOT', 1, 1, 3],
+    0x1a: ['BYTE', 2, 1, 3],
+    0x1b: ['SHL', 2, 1, 3],
+    0x1c: ['SHR', 2, 1, 3],
+    0x1d: ['SAR', 2, 1, 3],
+    0x20: ['SHA3', 2, 1, 30],
+    0x30: ['ADDRESS', 0, 1, 2],
+    0x31: ['BALANCE', 1, 1, 20],
+    0x32: ['ORIGIN', 0, 1, 2],
+    0x33: ['CALLER', 0, 1, 2],
+    0x34: ['CALLVALUE', 0, 1, 2],
+    0x35: ['CALLDATALOAD', 1, 1, 3],
+    0x36: ['CALLDATASIZE', 0, 1, 2],
+    0x37: ['CALLDATACOPY', 3, 0, 3],
+    0x38: ['CODESIZE', 0, 1, 2],
+    0x39: ['CODECOPY', 3, 0, 3],
+    0x3a: ['GASPRICE', 0, 1, 2],
+    0x3b: ['EXTCODESIZE', 1, 1, 20],
+    0x3c: ['EXTCODECOPY', 4, 0, 20],
+    0x3d: ['RETURNDATASIZE', 0, 1, 2],
+    0x3e: ['RETURNDATACOPY', 3, 0, 3],
+    0x3f: ['EXTCODEHASH', 1, 1, 400],
+    0x40: ['BLOCKHASH', 1, 1, 20],
+    0x41: ['COINBASE', 0, 1, 2],
+    0x42: ['TIMESTAMP', 0, 1, 2],
+    0x43: ['NUMBER', 0, 1, 2],
+    0x44: ['DIFFICULTY', 0, 1, 2],
+    0x45: ['GASLIMIT', 0, 1, 2],
+    0x50: ['POP', 1, 0, 2],
+    0x51: ['MLOAD', 1, 1, 3],
+    0x52: ['MSTORE', 2, 0, 3],
+    0x53: ['MSTORE8', 2, 0, 3],
+    0x54: ['SLOAD', 1, 1, 50],
+    0x55: ['SSTORE', 2, 0, 0],
+    0x56: ['JUMP', 1, 0, 8],
+    0x57: ['JUMPI', 2, 0, 10],
+    0x58: ['PC', 0, 1, 2],
+    0x59: ['MSIZE', 0, 1, 2],
+    0x5a: ['GAS', 0, 1, 2],
+    0x5b: ['JUMPDEST', 0, 0, 1],
+    0xa0: ['LOG0', 2, 0, 375],
+    0xa1: ['LOG1', 3, 0, 750],
+    0xa2: ['LOG2', 4, 0, 1125],
+    0xa3: ['LOG3', 5, 0, 1500],
+    0xa4: ['LOG4', 6, 0, 1875],
+    0xf0: ['CREATE', 3, 1, 32000],
+    0xf1: ['CALL', 7, 1, 40],
+    0xf2: ['CALLCODE', 7, 1, 40],
+    0xf3: ['RETURN', 2, 0, 0],
+    0xf4: ['DELEGATECALL', 6, 0, 40],
+    0xf4: ['CREATE2', 4, 1, 32000],
+    0xfa: ['STATICCALL', 6, 1, 40],
+    0xfd: ['REVERT', 2, 0, 0],
+    0xff: ['SUICIDE', 1, 0, 0],
+}
+valid_opcodes = list(opcodes.keys())
 
 
 class RndCodeInstr(_RndCodeBase):
@@ -20,40 +98,45 @@ class RndCodeInstr(_RndCodeBase):
     MIN_CONTRACT_SIZE = 4
     MAX_CONTRACT_SIZE = 8816
 
+
     def random_code_byte_sequence(self, length=None):
         # todo: add gauss histogramm random.randgauss(min,max,avg) - triangle is not really correct here
         length = length or int(random.triangular(self.MIN_CONTRACT_SIZE, 2 * self.AVERAGE_CONTRACT_SIZE + self.MIN_CONTRACT_SIZE))  # use gauss
 
-        rnd_prolog = WeightedRandomizer(self.LIKELYHOOD_PROLOG_BY_OPCODE_INT)
-        rnd_epilog = WeightedRandomizer(self.LIKELYHOOD_EPILOG_BY_OPCODE_INT)  # not completely true as this incorps. pro/epilog
-        rnd_corpus = WeightedRandomizer(self.LIKELYHOOD_BY_OPCODE_INT)
-
+#        rnd_prolog = WeightedRandomizer(self.LIKELYHOOD_PROLOG_BY_OPCODE_INT)
+#        rnd_epilog = WeightedRandomizer(self.LIKELYHOOD_EPILOG_BY_OPCODE_INT)  # not completely true as this incorps. pro/epilog
+#        rnd_corpus = WeightedRandomizer(self.LIKELYHOOD_BY_OPCODE_INT)
+#       
         b = []
-        for _ in range(128):
-            b.append(rnd_prolog.random())
-            #  hack ahead -
-            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-                # 10% chance of inserting a constantinople instr
-                if self.randomPercent() < 5:
-                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
+        for _ in range(length):
+#            b.append(valid_opcodes[random.randint(0,len(valid_opcodes)-1)])
+            b.append(random.choice(valid_opcodes))
 
-        for _ in range(length - 128 * 2):
-            b.append(rnd_corpus.random())
-            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-                # 10% chance of inserting a constantinople instr
-                if self.randomPercent() < 5:
-                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
-
-        for _ in range(128):
-            b.append(rnd_epilog.random())
-            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-                # 10% chance of inserting a constantinople instr
-                if self.randomPercent() < 5:
-                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
-
+#        for _ in range(128):
+#            b.append(rnd_prolog.random())
+#            #  hack ahead -
+#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
+#                # 10% chance of inserting a constantinople instr
+#                if self.randomPercent() < 5:
+#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
+#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
+#
+#        for _ in range(length - 128 * 2):
+#            b.append(rnd_corpus.random())
+#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
+#                # 10% chance of inserting a constantinople instr
+#                if self.randomPercent() < 5:
+#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
+#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
+#
+#        for _ in range(128):
+#            b.append(rnd_epilog.random())
+#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
+#                # 10% chance of inserting a constantinople instr
+#                if self.randomPercent() < 5:
+#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
+#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
+#
         return bytes(b)
 
     def _fill_arguments(self, instructions):
@@ -138,7 +221,7 @@ class RndCodeInstr(_RndCodeBase):
                     args_filled = True
                 elif instr.name=="EXTCODEHASH":
                     # todo: rework
-                    yield create_push_for_data(self.randomSmallUniInt())  # slot
+                    yield create_push_for_data(RndDestAddress().as_bytes())  # slot
                     args_filled = True
                 elif instr.category in ("bitwise-logic","comparison"):
                     for _ in instr.args:

--- a/evmlab/tools/statetests/rndval/codesmart.py
+++ b/evmlab/tools/statetests/rndval/codesmart.py
@@ -76,7 +76,7 @@ opcodes = {
     0xf2: ['CALLCODE', 7, 1, 40],
     0xf3: ['RETURN', 2, 0, 0],
     0xf4: ['DELEGATECALL', 6, 0, 40],
-    0xf4: ['CREATE2', 4, 1, 32000],
+    0xf5: ['CREATE2', 4, 1, 32000],
     0xfa: ['STATICCALL', 6, 1, 40],
     0xfd: ['REVERT', 2, 0, 0],
     0xff: ['SUICIDE', 1, 0, 0],
@@ -85,7 +85,7 @@ valid_opcodes = list(opcodes.keys())
 const_opcodes = [0x1b, #: ['SHL', 2, 1, 3],
                     0x1c, #: ['SHR', 2, 1, 3],
                     0x1d, #: ['SAR', 2, 1, 3],
-                    0xf4, #: ['CREATE2', 4, 1, 32000],
+                    0xf5, #: ['CREATE2', 4, 1, 32000],
                     0x3f] #: ['EXTCODEHASH', 1, 1, 400],
 
 constantinople_skewed_set = valid_opcodes + const_opcodes + const_opcodes  + const_opcodes 

--- a/evmlab/tools/statetests/templates/object_based.py
+++ b/evmlab/tools/statetests/templates/object_based.py
@@ -15,10 +15,10 @@ TEMPLATE_RandomStateTest = {
             "compressed_random_state": rndval.RandomSeed(),
         },
         "_info": {
-            "comment": "",
+            "comment": "This test was generated from Evmlab",
             "filledwith": "evmlab",
-            "lllcversion": "not availalbe",
-            "source": "not available"
+            "lllcversion": "not available",
+            "source": "not available",
             "sourceHash": "not available"
         },
         "env": {

--- a/evmlab/tools/statetests/templates/object_based.py
+++ b/evmlab/tools/statetests/templates/object_based.py
@@ -14,17 +14,24 @@ TEMPLATE_RandomStateTest = {
         "_fuzz": {
             "compressed_random_state": rndval.RandomSeed(),
         },
+        "_info": {
+            "comment": "",
+            "filledwith": "evmlab",
+            "lllcversion": "not availalbe",
+            "source": "not available"
+            "sourceHash": "not available"
+        },
         "env": {
             "currentCoinbase": rndval.RndAddress(),
             "currentDifficulty": "0x20000",
-            "currentGasLimit": rndval.RndBlockGasLimit(),
+            "currentGasLimit": "0x1312D00", # Set to 20M for now
             "currentNumber": "1",
             "currentTimestamp": "1000",
             "previousHash": rndval.RndHash32()
         },
         "post": {"Byzantium" : [{ # dummy to make statetests happy
             "hash" : "0x00000000000000000000000000000000000000000000000000000000deadc0de",
-            "logs" : "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            "logs" : "0x00000000000000000000000000000000000000000000000000000000deadbeef",
             "indexes" : {"data":0, "gas": 0, "value":0}
             }]
             },  
@@ -96,7 +103,7 @@ OLD_TEMPLATE_RandomStateTest = {
             "source": "src/GeneralStateTestsFiller/stRandom2/randomStatetest386Filler.json",
             "sourceHash": "c9d4a1fbb5f614cb885897bc4714a4a553e13fa28ef952d975378780b591072c"
         },
-        "env": {
+        "env": { 
             "currentCoinbase": rndval.RndAddress(),
             "currentDifficulty": "0x20000",
             "currentGasLimit": rndval.RndBlockGasLimit(),

--- a/evmlab/tools/statetests/templates/object_based.py
+++ b/evmlab/tools/statetests/templates/object_based.py
@@ -78,7 +78,7 @@ TEMPLATE_RandomStateTest = {
             "gasPrice": rndval.RndGasPrice(),
             "nonce": rnd_nonce,
             "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
-            "to": rndval.RndDestAddress(),
+            "to": rndval.RndDestAddressOrZero(),
             "value": [rnd_send_value]
         }
     }

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -12,9 +12,10 @@ FNULL = open(os.devnull, 'w')
 
 valid_opcodes = opcodes.reverse_opcodes.keys()
 
-# The 'stateRoot' is disabled, because of false positives
-# with the new execution model where the coinbase is touched
-INCLUDE_STATEROOT=False
+# The 'stateRoot' comparison can be disabled, in which case
+# the analysis will check only the internal states after every 
+# opcode, but ignore the poststate roothash
+INCLUDE_STATEROOT=True
 
 strip_0x = remove_0x_head
 bstrToInt = lambda b_str: int(b_str.replace("b", "").replace("'", ""))

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -12,9 +12,9 @@ FNULL = open(os.devnull, 'w')
 
 valid_opcodes = opcodes.reverse_opcodes.keys()
 
-# The 'stateRoot' output is missing from some clients (parity). 
-# Enable this once they implement it
-INCLUDE_STATEROOT=True
+# The 'stateRoot' is disabled, because of false positives
+# with the new execution model where the coinbase is touched
+INCLUDE_STATEROOT=False
 
 strip_0x = remove_0x_head
 bstrToInt = lambda b_str: int(b_str.replace("b", "").replace("'", ""))

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -546,7 +546,7 @@ def testSpeedGenerateTests():
         #test.update(t)
         test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
         x = str(test_obj)
-        #print(x)
+        print(test_obj["randomStatetest"]["transaction"]["to"])
         x1 = time.time()
         print("%d %f (tot %f/s)" % (counter, x1 - x0, counter / (x1 - start) ))
         counter = counter +1

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -525,8 +525,38 @@ def main():
     TestExecutor().startFuzzing()
 
 
+def testSpeedGenerateTests():
+    """This method produces json-files, each containing one statetest, with _one_ poststate. 
+    It stores each test with a filename that is unique per user and per process, so that two
+    paralell executions should not interfere with eachother. 
+    
+    returns (filename, object) 
+    """
+
+    from evmlab.tools.statetests import templates
+    from evmlab.tools.statetests import randomtest
+    import time
+    t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
+    test = {}
+    test.update(t)
+    counter = 0
+    start = time.time()
+    while True: 
+        x0 = time.time()
+        #test.update(t)
+        test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
+        x = str(test_obj)
+        #print(x)
+        x1 = time.time()
+        print("%d %f (tot %f/s)" % (counter, x1 - x0, counter / (x1 - start) ))
+        counter = counter +1
+
+
 if __name__ == '__main__':
     main()
+    #testSpeedGenerateTests()
+
+
 
 
 def testParityInterleavedOutput():

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -99,14 +99,14 @@ class StateTest():
     """ This class represents a single statetest, with a single post-tx result: one transaction
     executed on one single fork
     """
-    def __init__(self, statetest, counter):
+    def __init__(self, statetest, counter, overwriteFork=True):
         self.number = None
         self.identifier = "%s-%d" %(cfg.host_id, counter)
 
-        # Replace the fork with what we are currently configured for
-        postState = statetest['randomStatetest']['post']['Byzantium']
-        del(statetest['randomStatetest']['post']['Byzantium'])
-        statetest['randomStatetest']['post'][cfg.fork_config] = postState 
+        if overwriteFork and "Byzantium" in statetest['randomStatetest']['post'].keys():
+            # Replace the fork with what we are currently configured for
+            postState = statetest['randomStatetest']['post'].pop('Byzantium')
+            statetest['randomStatetest']['post'][cfg.fork_config] = postState 
 
 
         # Replace the top level name 'randomStatetest' with something meaningful (same as filename)        

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -404,7 +404,7 @@ def end_processes(test):
         logger.info("Processed %s steps for %s on test %s" % (tracelen, client_name, test.identifier))
     
     stats = VMUtils.traceStats(canon_steps)
-    #print(stats)
+    print(stats)
     #print(canon_steps)
     #print("\n".join(canon_trace))
     return (tracelen, stats)
@@ -554,40 +554,3 @@ def testSpeedGenerateTests():
 
 if __name__ == '__main__':
     main()
-    #testSpeedGenerateTests()
-
-
-
-
-def testParityInterleavedOutput():
-    """ Tests interleaved stdout/stderr, which happens when using Stream=True docker execution
-    Expected output:
-
-    {'pc': 0, 'gas': '0x477896', 'op': 91, 'depth': 0, 'stack': []}
-    {'pc': 1, 'gas': '0x477895', 'op': 96, 'depth': 0, 'stack': []}
-    {'pc': 3, 'gas': '0x477892', 'op': 97, 'depth': 0, 'stack': ['0xd1']}
-    {'pc': 6, 'gas': '0x47788f', 'op': 97, 'depth': 0, 'stack': ['0xd1', '0xc09a']}
-    {'pc': 9, 'gas': '0x47788c', 'op': 111, 'depth': 0, 'stack': ['0xd1', '0xc09a', '0xa7f6']}
-    {'pc': 26, 'gas': '0x477889', 'op': 20, 'depth': 0, 'stack': ['0xd1', '0xc09a', '0xa7f6', '0x948ec1a91609740f44b8d0c74c4785d8']}
-    {'pc': 27, 'gas': '0x477886', 'op': 99, 'depth': 0, 'stack': ['0xd1', '0xc09a', '0x0']}
-    {'pc': 32, 'gas': '0x477883', 'op': 81, 'depth': 0, 'stack': ['0xd1', '0xc09a', '0x0', '0x4ebfdb04']}
-    {'stateRoot': '3b63251e410b65ae32806a89e101b93e81b51096e4c00f6c3b547fe43350f504'}
- 
-    """   
-    data = """# command
-# /parity-evm state-test --std-json /testfiles/martin-Tue_08_30_12-19208-13127-test.json
-
-{"test":"randomStatetestmartin-Tue_08_30_12-19208-13127:byzantium:0","action":"starting"}
-{"pc":0,"op":91,"opName":"JUMPDEST","gas":"0x477896","stack":[],"storage":{},"depth":1}
-{"pc":1,"op":96,"opName":"PUSH1","gas":"0x477895","stack":[],"storage":{},"depth":1}
-{"pc":3,"op":97,"opName":"PUSH2","gas":"0x477892","stack":["0xd1"],"storage":{},"depth":1}
-{"pc":6,"op":97,"opName":"PUSH2","gas":"0x47788f","stack":["0xd1","0xc09a"],"storage":{},"depth":1}
-{"pc":9,"op":111,"opName":"PUSH16","gas":"0x47788c","stack":["0xd1","0xc09a","0xa7f6"],"storage":{},"depth":1}
-{"pc":26,"op":20,"opName":"EQ","gas":"0x477889","stack":["0xd1","0xc09a","0xa7f6","0x948ec1a91609740f44b8d0c74c4785d8"],"storage":{},"depth":1}
-{"pc":27,"op":99,"opName":"PUSH4","gas":"0x477886","stack":["0xd1","0xc09a","0x0"],"storage":{},"depth":1}
-{"pc":32,"op":81,"opName":"MLOAD","gas":"0x{"error":"State root mismatch (got: 0x3b63251e410b65ae32806a89e101b93e81b51096e4c00f6c3b547fe43350f504, expected: 0x00000000000000000000000000000000000000000000000000000000deadc0de)","gasUsed":"0x266573df9038e0","time":273}
-477883","stack":["0xd1","0xc09a","0x0","0x4ebfdb04"],"storage":{},"depth":1}"""
-    output = VMUtils.ParityVM.canonicalized(data.split("\n"))
-    print("\n".join([str(x) for x in output]))
-
-

--- a/utilities/test_minimizer.py
+++ b/utilities/test_minimizer.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Executes state tests on multiple clients, checking for EVM trace equivalence
+
+"""
+import json, sys, re, os, subprocess, io, itertools, traceback, time, collections, shutil
+from evmlab import vm as VMUtils
+from fuzzer import startDaemons, StateTest, start_processes, end_processes, processTraces
+import copy
+
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+def capcode(code):
+    if len(code) > 20000:
+        return code[:-5000]
+    if len(code) > 10000:
+        return code[:-2000]
+    if len(code) > 1000:
+        return code[:-200]
+    if len(code) > 100:
+        return code[:-10]
+    if len(code) > 10:
+        return code[:-4]
+
+    return code[:-2]
+
+
+def mutate(test_obj, counter ):
+    counter = 0
+    original = copy.deepcopy(test_obj)
+    print(test_obj["randomStatetest"]["pre"].keys())
+    accounts = test_obj["randomStatetest"]["pre"]
+    prestate_account_list = list(accounts.keys())
+    print("presetate accounts" , prestate_account_list)
+    print("yielding original")
+    yield(test_obj)
+    for a in prestate_account_list:
+        deleted = accounts.pop(a)
+        print("deleted account ", a)
+        rollback = yield copy.deepcopy(test_obj)
+        if rollback:
+            print("undeleted account ", a)
+            accounts[a] = deleted
+
+    # Done miminizing accounts, let's remove code
+    prestate_account_list = list(accounts.keys())
+    for add, data in accounts.items():
+        code = data["code"]
+        data["code"] = ""
+        print("deleted code for ",add)
+        rollback = yield copy.deepcopy(test_obj)
+        if rollback:
+            print("undeleted code for ", a)
+            data["code"] = code
+
+    # Done miminizing accounts, let's minimize input
+    tx = test_obj["randomStatetest"]["transaction"]
+    if len(tx["data"][0]) > 0:
+        tx["data"][0] = ""
+        rollback = yield copy.deepcopy(test_obj)
+        if rollback:
+            tx["data"][0] = data
+
+    # Done miminizing accounts, let's cap code
+    prestate_account_list = list(accounts.keys())
+    for add, data in accounts.items():
+        if "code" in data.keys():
+            code = data["code"]
+            while True:
+                newcode = capcode(code)
+                if newcode == "":
+                    break
+                data["code"] = newcode
+                print("shortened code for ",add, len(data["code"]))
+                rollback = yield copy.deepcopy(test_obj)
+                if rollback:
+                    print("unshortened code for ",add)
+                    data["code"] = code
+                    break
+                else:
+                    code = newcode
+                    continue
+
+    yield(test_obj)
+        #done
+
+def forkify(test_obj):
+    original = copy.deepcopy(test_obj)
+    postState = test_obj["randomStatetest"]["post"]
+    current_fork = list(postState.keys())[0]
+    triggered_forks = []
+
+    for forkname in ["Frontier", "Homestead", "EIP150","EIP158", "Byzantium", "Constantinople"]:
+        postState[forkname] = postState.pop(current_fork)
+        current_fork = forkname
+        consensus = yield copy.deepcopy(test_obj)
+        if consensus:
+            print("Test did not trigger on", forkname)
+        else:
+            print("Test triggered on", forkname)
+            triggered_forks.append(forkname)
+
+
+
+class Mimizer():
+    def __init__(self):
+        self.counter = 0
+
+    def isConsensus(self, test_obj):
+        """ Returns true if the clients are in consensus over the testcase """
+        self.counter = self.counter +1 
+        test = StateTest(copy.deepcopy(test_obj), self.counter, overwriteFork=False)
+        test.writeToFile()
+        start_processes(test)
+        data = end_processes(test)
+        failingTestcase = processTraces(test, forceSave = False)
+        if failingTestcase is not None:
+            return False
+        return True
+
+
+    def reportResult(self, testcase, typ, path):
+        minified = "./%s.%s" % (typ, os.path.basename(path))
+        with open(minified, "w+") as f:
+            json.dump(testcase, f)
+        print("Stored %s" % minified)
+
+    def startMutation(self, test_original, path):
+        counter = 1
+        name =  list(test_original.keys())[0]
+        print("pre", test_original.keys())
+        testcase = {"randomStatetest" : test_original[name]}
+        print("pos", testcase.keys())
+        consensus = self.isConsensus(testcase)
+        if consensus:
+            print("No consensus error triggered!")
+            return
+        mutator = mutate(testcase, 0)
+        next(mutator)
+        # First minimize
+        while True:
+            # Roll back incase of consensus
+            try:
+                testcase = mutator.send(consensus)
+                consensus = self.isConsensus(testcase)
+                print("Consensus" , consensus, "count", counter) 
+                counter = counter + 1
+            except StopIteration as e:
+                break
+
+        self.reportResult(testcase, "minified", path)
+        
+        # Then maximise: try different forks
+        forker = forkify(testcase)
+        testcase = next(forker)
+        while True:
+            # Roll back incase of consensus
+            try:
+                testcase = forker.send(consensus)
+                consensus = self.isConsensus(testcase)
+                if not consensus:
+                    # Find out forkname
+                    current_fork = list(testcase["randomStatetest"]["post"].keys())[0]
+                    self.reportResult(testcase, "%s.minified" % current_fork , path)
+                counter = counter + 1
+            except StopIteration as e:
+                break
+
+        
+
+
+def main(args):
+    if len(args) < 1:
+        logger.warning("please provide a filename")
+        return
+
+    path = args[0] 
+    testcase = None
+    # Can we read the testfile? 
+    with open(path, "r") as f:
+        testcase = json.load(f)
+    # Start all docker daemons that we'll use during the execution
+    startDaemons()
+    
+    Mimizer().startMutation(testcase, path)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
I investigated why traces were so short, and found and fixed a lot of errors.. 

- ethereum-dasm incorrectly padded with zeroes after certain ops, like `MSTORE`: https://github.com/tintinweb/ethereum-dasm/pull/9 
- Transaction-create never happened
- The address type used `to_bytes`, which fell back to the super object, which always returned random bytes. 
- Many ops were using too large memory areas for their operands. 

Also, instructions were incorrectly generating code with this construct:
```
instructions = [asm_registry.create_instruction(opcode=opcode) for opcode in self.random_code_byte_sequence(self.length)]
```
Using `self.length` instead of `length`. This caused the size of generated code to blow up something humongous. 