### PR TITLE
Rework io

### DIFF
--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -134,8 +134,11 @@ class RawStateTest():
             logger.debug("Removing trace file %s" % f)
             os.remove(f)
 
+    def tempTraceFilename(self, client):
+        return "%s-%s.trace.log" % (self.identifier, client)
+
     def tempTraceLocation(self, client):
-        return os.path.abspath("%s/%s-%s.trace.log" % (cfg.logfilesPath(),self.identifier, client))
+        return os.path.abspath("%s/%s" % (cfg.logfilesPath(),self.tempTraceFilename(client)))
 
     def storeTrace(self, client, output, command):
         filename = self.tempTraceLocation(client)
@@ -254,13 +257,11 @@ def startDaemon(clientname, imagename):
         name=clientname,
         detach=True, 
         remove=True,
-        volumes={cfg.testfilesPath():{ 'bind':'/testfiles/', 'mode':"rw"}})
+        volumes={
+            cfg.testfilesPath():{ 'bind':'/testfiles/', 'mode':"rw"},
+            cfg.logfilesPath():{ 'bind':'/logs/', 'mode':"rw"},
+            })
 
-        ##    cmd = ["docker", "run", "--rm", "-t",
-        ##          "--name", clientname, 
-        ##         "-v", "/tmp/testfiles/:/testfiles/", 
-        ##       "--entrypoint","sleep", imagename, "356d"]
-        ##  return {'proc':VMUtils.startProc(cmd ), 'cmd': " ".join(cmd), 'output' : 'stdout'}
     logger.info("Started docker daemon %s %s" % (imagename, clientname))
 
 def killDaemon(clientname):
@@ -315,7 +316,6 @@ def execInDocker(name, cmd, stdout = True, stderr=True):
     #logger.info("executing in %s: %s" %  (name," ".join(cmd)))
     container = dockerclient.containers.get(name)
     (exitcode, output) = container.exec_run(cmd, stream=stream,stdout=stdout, stderr = stderr)     
-    logger.info("Executing %s took in %f seconds" % (name, time.time() - start_time))
     
 
     # If stream is False, then docker soups up the output, and we just decode it once
@@ -333,6 +333,9 @@ def execInDocker(name, cmd, stdout = True, stderr=True):
          'cmd':" ".join(cmd)
          }
 
+def shWrap(cmd, output):
+    """ Wraps a command in /bin/sh, with output to the given file"""
+    return ["/bin/sh","-c"," ".join(cmd) + " &> /logs/%s" % output]
 
 
 def startGeth(test):
@@ -345,12 +348,14 @@ def startGeth(test):
 
     """
     cmd = ["evm","--json","--nomemory","statetest","/testfiles/%s" % os.path.basename(test.filename())]
+    cmd = shWrap(cmd, test.tempTraceFilename('geth'))
     return execInDocker("geth", cmd, stdout = False)
-    
+
 
 def startParity(test):
-#    cmd = ["/parity-evm","state-test", "--std-json","/testfiles/%s" % os.path.basename(test.filename())]
-    cmd = ["/bin/sh","-c","/parity-evm state-test --std-json /testfiles/%s 1>&2" % os.path.basename(test.filename())]
+    cmd = ["/parity-evm","state-test", "--std-json","/testfiles/%s" % os.path.basename(test.filename())]
+    #cmd = ["/bin/sh","-c","/parity-evm state-test --std-json /testfiles/%s 1>&2" % os.path.basename(test.filename())]
+    cmd = shWrap(cmd,test.tempTraceFilename('parity'))
     return execInDocker("parity", cmd)
 
 def startHera(test):
@@ -410,18 +415,25 @@ def end_processes(test):
     canon_steps = None
     canon_trace = []
     for (proc_info, client_name) in test.procs:
-        logger.info("Proc '%s'" % client_name)
+        t0 = time.time()
         full_trace = proc_info["output"]()
-        test.storeTrace(client_name, full_trace,proc_info['cmd'])
+        t1 = time.time()
+        #logger.info("Wait for %s took in %.02f milliseconds" % (client_name, 1000 * (t1 - t0)))
+        #test.storeTrace(client_name, full_trace,proc_info['cmd'])
         canonicalizer = canonicalizers[client_name]
-        canon_steps = canonicalizer(full_trace.split("\n"))
-        canon_trace = [VMUtils.toText(step) for step in canon_steps]
+        canon_steps = []
+        with open(test.tempTraceLocation(client_name)) as output:
+            canon_step_generator = canonicalizer(output)
+            canon_trace = [VMUtils.toText(step) for step in canon_step_generator]
         test.canon_traces.append(canon_trace)
         tracelen = len(canon_trace)
-        logger.info("Processed %s steps for %s on test %s" % (tracelen, client_name, test.identifier))
-    
+        t2 = time.time()
+        logger.info("Processed %s steps for %s on test %s, wtime: %.02f ms, pTime:%.02f ms" 
+            % (tracelen, client_name, test.identifier, 1000 * (t1 - t0), 1000 * (t2 - t1)))
+
+
     stats = VMUtils.traceStats(canon_steps)
-    print(stats)
+    #print(stats)
     #print(canon_steps)
     #print("\n".join(canon_trace))
     return (tracelen, stats)
@@ -499,7 +511,7 @@ class TestExecutor():
         for test in generateTests():
             n = n+1
             #Prepare the current test
-            logger.info("Test id: %s" % test.id())
+            #logger.info("Test id: %s" % test.id())
             test.writeToFile()
 
             # Start new procs

--- a/utilities/test_executor.py
+++ b/utilities/test_executor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Executes state tests on multiple clients, checking for EVM trace equivalence
+
+"""
+import json, sys, re, os, subprocess, io, itertools, traceback, time, collections, shutil
+from evmlab import vm as VMUtils
+from fuzzer import startDaemons, RawStateTest, start_processes, end_processes, processTraces
+import copy
+
+import logging
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+def runTest(test_obj, filename):
+    id = "".join(filename.split("-")[:-1])
+    print("id",id )
+    test = RawStateTest(copy.deepcopy(test_obj),id, filename)
+    test.writeToFile()
+    start_processes(test)
+    end_processes(test)
+    failingTestcase = processTraces(test, forceSave = False)
+    if failingTestcase is None:
+            return
+
+    
+
+def main(args):
+    if len(args) < 1:
+        logger.warning("please provide a filename")
+        return
+
+    path = args[0] 
+    testcase = None
+    # Can we read the testfile? 
+    with open(path, "r") as f:
+        testcase = json.load(f)
+    # Start all docker daemons that we'll use during the execution
+    startDaemons()
+    
+    runTest(testcase, os.path.basename(path))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
This fixes https://github.com/ethereum/evmlab/issues/82  , and should in general be a lot faster. 

1. Docker execution of clients now does not shuffle as much data, instead all output is piped directly into a file, which is accessible through the host filesystem. 
2. Since we're now reading trace from a file instead of 'arbitrary-chunks-of-data', we can use the pythonic way of reading line by line, into a generator
3. Since the vm canonicalizers now get the input line by line, it has been converted into a generator, which `yield`s the steps. 

This PR has several benefits:
1. No io buffers that gets overfilled between host and clients
2. A lot less data shuffling over IO
3. A lot less in-memory data during processing

I also added some more timing stats and removed some unnecessary printouts. I wil take it for a spin on prod to see how it flies. 