### PR TITLE
Rework io

### DIFF
--- a/evmlab/compiler.py
+++ b/evmlab/compiler.py
@@ -40,6 +40,7 @@ EXTCODESIZE   = 0x3b # Pops: 1, Pushes: 1, Gas: 20],
 EXTCODECOPY   = 0x3c # Pops: 4, Pushes: 0, Gas: 20],
 RETURNDATASIZE= 0x3D
 RETURNDATACOPY= 0x3E
+EXTCODEHASH   = 0x3F
 BLOCKHASH     = 0x40 # Pops: 1, Pushes: 1, Gas: 20],
 
 COINBASE      = 0x41 # Pops: 0, Pushes: 1, Gas: 2],

--- a/evmlab/tools/statetests/rndval/address.py
+++ b/evmlab/tools/statetests/rndval/address.py
@@ -89,11 +89,13 @@ class RndAddress(RndByteSequence):
                     return self._get_rnd_address_from_list(self.addresses.get(RndAddressType.BYZANTIUM_PRECOMPILED))
                 return self._get_rnd_address_from_list(self.addresses.get(RndAddressType.PRECOMPILED))
 
+# CREATE is disabled for now -- the logic below could fill the template with to: "0x", which is not correct. The correct
+# transaction would either have to: None, or no to-field present. 
             # CREATE  (if all or create is set)
             #if types_set != set([RndAddressType.PRECOMPILED, RndAddressType.STATE_ACCOUNT]):
-            if types_set.intersection([RndAddressType.SPECIAL_ALL, RndAddressType.SPECIAL_CREATE]):
-                if self.randomPercent()<probabilities["emptyAddressProbability"]:
-                    return ""
+#            if types_set.intersection([RndAddressType.SPECIAL_ALL, RndAddressType.SPECIAL_CREATE]):
+#                if self.randomPercent()<probabilities["emptyAddressProbability"]:
+#                    return ""
 
             # RANDOM
             if self.randomPercent()<probabilities["randomAddressProbability"]:

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -32,25 +32,39 @@ def toHexQuantities(vals):
     """ Formats a list of values into a list of hex-encoded values """
     return ['0x{0:01x}'.format(parse_int_or_hex(val)) for val in vals]
 
-def traceStats(canon_trace):
-    """traceStats returns some statistics about the trace"""
-    #canon_trace = [{'pc': 0, 'gas': '0x41f0fd', 'op': 97, 'depth': 0, 'stack': [], 'opname': 'PUSH2'}, {'pc': 3, 'gas': '0x41f0fa', 'op': 103, 'depth': 0, 'stack': ['0x7bb8'], 'opname': 'PUSH8'}, {'pc': 12, 'gas': '0x41f0f7', 'op': 63, 'depth': 0, 'stack': ['0x7bb8', '0xa4fb3dba573f5003'], 'opname': 'EXTCODEHASH'}]
+class Stats():
+    def __init__(self):
+        self.maxdepth= 0
+        self.numConstantinople = 0
+        self.stopped = False
 
-    maxdepth = 0 
-    numConstantinople = 0 
-    for step in canon_trace:
-        if "depth" in step.keys() and int(step['depth']) > maxdepth:
-            maxdepth = int(step['depth'])
-        if "opname" in step:
-            op = step["opname"]
-            if op in ["SHR", "SAR", "SHL", "EXTCODEHASH","CREATE2"]:
-                numConstantinople = numConstantinople + 1
-    
+    def traceStats(self, canon_trace):
+        """traceStats returns some statistics about the trace"""
+        #canon_trace = [{'pc': 0, 'gas': '0x41f0fd', 'op': 97, 'depth': 0, 'stack': [], 'opname': 'PUSH2'}, {'pc': 3, 'gas': '0x41f0fa', 'op': 103, 'depth': 0, 'stack': ['0x7bb8'], 'opname': 'PUSH8'}, {'pc': 12, 'gas': '0x41f0f7', 'op': 63, 'depth': 0, 'stack': ['0x7bb8', '0xa4fb3dba573f5003'], 'opname': 'EXTCODEHASH'}]
+        
 
-    return {
-        "maxDepth": maxdepth, 
-        "constatinopleOps": numConstantinople
-    }
+        for step in canon_trace:
+            if self.stopped:
+                yield step
+                continue
+                
+            if "depth" in step.keys() and int(step['depth']) > self.maxdepth:
+                self.maxdepth = int(step['depth'])
+            if "opname" in step:
+                op = step["opname"]
+                if op in ["SHR", "SAR", "SHL", "EXTCODEHASH","CREATE2"]:
+                    self.numConstantinople = self.numConstantinople + 1
+            yield step
+
+    def stop(self):
+        self.stopped = True
+
+    def result(self):      
+        return {
+            "maxDepth": self.maxdepth, 
+            "constatinopleOps": self.numConstantinople
+        }
+
 
 def toText(op):
     if len(op.keys()) == 0:

--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -47,12 +47,11 @@ class Stats():
             if self.stopped:
                 yield step
                 continue
-                
+
             if "depth" in step.keys() and int(step['depth']) > self.maxdepth:
                 self.maxdepth = int(step['depth'])
-            if "opname" in step:
-                op = step["opname"]
-                if op in ["SHR", "SAR", "SHL", "EXTCODEHASH","CREATE2"]:
+            if "op" in step:
+                if step["op"] in [0x1b, 0x1c, 0x1d, 0x3F,0xF5]:
                     self.numConstantinople = self.numConstantinople + 1
             yield step
 


### PR DESCRIPTION
Various fixes

- Disable attempt to make empty `to`, but which just results in the `to` field being `0x`, which is not the same as absent or `null`. It just makes the test fail. 
- Make stat gen a filter/iterator
- Increase paralellism to `10`, so that `10` tests are started before we try to read the output from the first test. 