### PR TITLE
use RndCode2 based on evmcodegen and evmdasm

### DIFF
--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -23,3 +23,10 @@ except ImportError as ie:
     RndCode = RndCodeBytes
     logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
     logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
+
+try:
+    from .codesmart2 import RndCode2
+    RndCode = RndCode2
+except ImportError as ie:
+    logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
+    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")

--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -24,9 +24,9 @@ except ImportError as ie:
     logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
     logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
 
-try:
-    from .codesmart2 import RndCode2
-    RndCode = RndCode2
-except ImportError as ie:
-    logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
-    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
+#try:
+#    from .codesmart2 import RndCode2
+#    RndCode = RndCode2
+#except ImportError as ie:
+#    logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
+#    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -1,0 +1,38 @@
+from .code import _RndCodeBase
+from .address import RndAddress, RndDestAddress, RndAddressType
+import evmdasm
+import evmcodegen
+from evmcodegen.codegen import Rnd
+
+
+VALUEMAP ={
+    evmdasm.argtypes.Address: lambda: RndDestAddress().as_bytes(),
+    evmdasm.argtypes.Word: lambda: Rnd.byte_sequence(32),
+    evmdasm.argtypes.Timestamp: lambda: Rnd.byte_sequence(4),
+    evmdasm.argtypes.Data: lambda: Rnd.byte_sequence(Rnd.uni_integer(0, Rnd.opcode())),
+    evmdasm.argtypes.CallValue: lambda: Rnd.uni_integer(0,1024),
+    evmdasm.argtypes.Gas: lambda: Rnd.uni_integer(0,1024),
+    evmdasm.argtypes.Length: lambda: Rnd.small_memory_length_1024(),
+    evmdasm.argtypes.MemOffset: lambda: Rnd.small_memory_length_1024(),
+    evmdasm.argtypes.Index256: lambda: Rnd.uni_integer(1,256),
+    evmdasm.argtypes.Index64: lambda: Rnd.uni_integer(1,64),
+    evmdasm.argtypes.Index32: lambda: Rnd.length_32(),
+    evmdasm.argtypes.Byte: lambda: Rnd.byte_sequence(1),
+    evmdasm.argtypes.Bool: lambda: Rnd.byte_sequence(1),
+    evmdasm.argtypes.Value: lambda: Rnd.uni_integer(),
+    #evmdasm.argtypes.Label: lambda: 0xc0fefefe,  # this is handled by fix_code_layout (fix jumps)
+}
+
+class RndCode2(_RndCodeBase):
+    """
+    Random bytecode based on stat spread of instructions
+    """
+    placeholder = "[CODE]"
+
+    # analyzed based on statedump.json
+
+    def generate(self, length=None):
+        distribution = evmcodegen.distributions.EVM_CATEGORY  # override this in here to adjust weights
+        generator = evmcodegen.generators.distribution.GaussDistrCodeGen(distribution=distribution)
+        codegen = evmcodegen.codegen.CodeGen(generator=generator, valuemap=VALUEMAP)
+        return str(codegen.generate(length=length))

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -49,7 +49,7 @@ class InstructionMutators:
         len_instr = len(instructions)
         for _ in range(amount):
             index = Rnd.uni_integer(0, len_instr - 1)
-            instructions[index].randomize_operand()
+            Rnd.randomize_operand(instructions[index])
         return instructions
 
     @staticmethod
@@ -57,8 +57,8 @@ class InstructionMutators:
         len_instr = len(instructions)
         for _ in range(amount):
             index = Rnd.uni_integer(0, len_instr - 1)
-            instructions[index].insert(evmdasm.registry.create_instruction(opcode=Rnd.uni_integer(0x00, 0xff)))
-            instructions[index].randomize_operand()
+            instructions.insert(index, evmdasm.registry.create_instruction(opcode=Rnd.uni_integer(0x00, 0xff)))
+            Rnd.randomize_operand(instructions[index])
         return instructions
 
 
@@ -66,14 +66,21 @@ class BytecodeMutators:
 
     # add external mutation engines?
 
-    drop_byte = InstructionMutators.drop_item
+    @staticmethod
+    def drop_byte(bytecode, amount=1):
+        len_instr = len(bytecode)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            bytecode = bytecode[:index] + bytecode[index + 1:]
+        return bytecode
+
 
     @staticmethod
     def dup_byte(bytecode, amount=1):
         len_instr = len(bytecode)
         for _ in range(amount):
             index = Rnd.uni_integer(0, len_instr - 1)
-            bytecode = bytecode[:index] + bytecode[index] + bytecode[index] + bytecode[index+1:]
+            bytecode = bytecode[:index] + bytes([bytecode[index], bytecode[index]]) + bytecode[index+1:]
         return bytecode
 
     @staticmethod

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -120,6 +120,8 @@ class RndCode2(_RndCodeBase):
 
     def generate(self, length=None):
         distribution = evmcodegen.distributions.EVM_CATEGORY  # override this in here to adjust weights
+        if length is None:
+            length = distribution.avg
         generator = evmcodegen.generators.distribution.GaussDistrCodeGen(distribution=distribution)
 
         evmcode = evmcodegen.codegen.CodeGen()\

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -34,5 +34,12 @@ class RndCode2(_RndCodeBase):
     def generate(self, length=None):
         distribution = evmcodegen.distributions.EVM_CATEGORY  # override this in here to adjust weights
         generator = evmcodegen.generators.distribution.GaussDistrCodeGen(distribution=distribution)
-        codegen = evmcodegen.codegen.CodeGen(generator=generator, valuemap=VALUEMAP)
-        return str(codegen.generate(length=length))
+
+        evmcode = evmcodegen.codegen.CodeGen()\
+            .generate(generator=generator, length=length, min_gas=100)\
+            .fix_stack_arguments(valuemap=VALUEMAP)\
+            .fix_jumps()
+
+        evmcode.fix_stack_balance()
+
+        return "0x%s" % evmcode.assemble().as_hexstring

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -1,8 +1,10 @@
-from .code import _RndCodeBase
-from .address import RndAddress, RndDestAddress, RndAddressType
+import random
 import evmdasm
 import evmcodegen
 from evmcodegen.codegen import Rnd
+from .code import _RndCodeBase
+from .address import RndAddress, RndDestAddress, RndAddressType
+from .base import WeightedRandomizer
 
 
 VALUEMAP ={
@@ -23,6 +25,84 @@ VALUEMAP ={
     #evmdasm.argtypes.Label: lambda: 0xc0fefefe,  # this is handled by fix_code_layout (fix jumps)
 }
 
+
+class InstructionMutators:
+
+    @staticmethod
+    def drop_item(instructions, amount=1):
+        len_instr = len(instructions)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr-1 )
+            del instructions[index]
+        return instructions
+
+    @staticmethod
+    def dup_instruction(instructions, amount=1):
+        len_instr = len(instructions)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            instructions.insert(index, instructions[index].clone())
+        return instructions
+
+    @staticmethod
+    def randomize_operand(instructions, amount=1):
+        len_instr = len(instructions)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            instructions[index].randomize_operand()
+        return instructions
+
+    @staticmethod
+    def insert_random_instructions(instructions, amount=1):
+        len_instr = len(instructions)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            instructions[index].insert(evmdasm.registry.create_instruction(opcode=Rnd.uni_integer(0x00, 0xff)))
+            instructions[index].randomize_operand()
+        return instructions
+
+
+class BytecodeMutators:
+
+    # add external mutation engines?
+
+    drop_byte = InstructionMutators.drop_item
+
+    @staticmethod
+    def dup_byte(bytecode, amount=1):
+        len_instr = len(bytecode)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            bytecode = bytecode[:index] + bytecode[index] + bytecode[index] + bytecode[index+1:]
+        return bytecode
+
+    @staticmethod
+    def insert_random_bytes(bytecode, amount=1):
+        len_instr = len(bytecode)
+        for _ in range(amount):
+            index = Rnd.uni_integer(0, len_instr - 1)
+            bytecode = bytecode[:index] + Rnd.byte_sequence(1) + bytecode[index + 1:]
+        return bytecode
+
+    @staticmethod
+    def switch_random(bytecode, amount=1):
+        len_instr = len(bytecode)
+        size = Rnd.uni_integer(0, amount)
+        from_index = Rnd.uni_integer(0, len_instr - 1)   # bytecode[from_index:index+size]
+        to_index = Rnd.uni_integer(0, len_instr - 1)     # bytecode[to_index:index+size]
+
+        first_index=min(from_index, to_index)
+        second_index=max(from_index, to_index)
+
+        newcode = [bytecode[:first_index],                      #0
+                  bytecode[first_index:first_index+size],       #1  switch
+                  bytecode[first_index+size:second_index],      #2
+                  bytecode[second_index:second_index+size],     #3  switch
+                  bytecode[second_index+size:]]                 #4
+        bytecode = newcode[0] + newcode[3] + newcode[2] + newcode[1] + newcode[4]
+        return bytecode
+
+
 class RndCode2(_RndCodeBase):
     """
     Random bytecode based on stat spread of instructions
@@ -37,9 +117,35 @@ class RndCode2(_RndCodeBase):
 
         evmcode = evmcodegen.codegen.CodeGen()\
             .generate(generator=generator, length=length, min_gas=100)\
-            .fix_stack_arguments(valuemap=VALUEMAP)\
-            .fix_jumps()
 
-        evmcode.fix_stack_balance()
+        # fix the stack and code in 99.5% of cases
+        if Rnd.uni_integer(0,1000) <= 995:
+            evmcode.fix_stack_arguments(valuemap=VALUEMAP)\
+                .fix_jumps()
+
+        # fix stack balance in 95% of cases
+        if Rnd.percent() <= 95:
+            # balance it?
+            evmcode.fix_stack_balance()
+
+        ######## mutation ########
+
+        # mutate instructions in 1% of cases - likely invalid code
+        if Rnd.percent() <= 1:
+            weights = {InstructionMutators.randomize_operand: 60,
+                       InstructionMutators.drop_item: 10,
+                       InstructionMutators.dup_instruction: 20,
+                       InstructionMutators.insert_random_instructions: 10}
+            mutator = WeightedRandomizer(weights=weights)
+            evmcode.instructions = mutator.random()(evmcode.instructions,Rnd.uni_integer(1,3))
+
+        # mutate evmbytecode in 0.1% of  - very likely invalid code
+        if Rnd.uni_integer(0,1000) <= 1:
+            weights = {BytecodeMutators.dup_byte: 50,
+                       BytecodeMutators.insert_random_bytes: 10,
+                       BytecodeMutators.drop_byte: 20,
+                       BytecodeMutators.switch_random: 20}
+            mutator = WeightedRandomizer(weights=weights)
+            evmcode.instructions = evmdasm.EvmBytecode(mutator.random()(evmcode.assemble().as_bytes, Rnd.uni_integer(1, 3))).disassemble()
 
         return "0x%s" % evmcode.assemble().as_hexstring

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='Evmlab',
       extras_require={"consolegui": ["urwid"],
                       "abidecoder": ["ethereum-input-decoder"],
                       "docker": ["docker==3.0.0"],
-                      "fuzztests": ["docker==3.0.0"],
+                      "fuzztests": ["docker==3.0.0", "evmcodegen"],
                       }
       )


### PR DESCRIPTION
* https://github.com/tintinweb/evmdasm is now the central registry for instructions. it also provides disassembly manipulation functionality
* https://github.com/tintinweb/evmcodegen creates random evmcode and is based on evmdasm. it is split up in a generator part (generate code based on byte/instr/custom distribution) and a generic interface to generate evmcode.
* evmcodegen has not yet been published to pypi and needs to be installed before it can be used
* evmcodegen is missing some manipulation code (bitflipping, instr insertion, corruption, etc)

**dont merge yet**