### PR TITLE
refactor fuzzer.py for reusability and prepare cmdline/ini config merging

### DIFF
--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -225,7 +225,7 @@ class TestExecutor(object):
     def onFail(self, testcase):
         self.stats["fail_count"] = self.stats["fail_count"] + 1
         self.stats["total_count"] = self.stats["total_count"] + 1
-        self.failures.append(failingTestcase.listArtefacts())
+        self.failures.append(testcase.listArtefacts())
 
     def numFails(self):
         return self.stats["fail_count"]

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -130,7 +130,7 @@ class RawStateTest(object):
 
     def storeTrace(self, client, command):
         filename = self.tempTraceLocation(client)
-        logging.debug("%s full trace %s saved to %s" % (client, self.id(), filename))
+        logger.debug("%s full trace %s saved to %s" % (client, self.id(), filename))
         #       Not needed when docker-processes write directly into files
         #        with open(filename, "w+") as f:
         #            f.write("# command\n")
@@ -375,7 +375,7 @@ class Fuzzer(object):
                 logger.warning("Not a docker client %s", client_name)
 
     def start_daemon(self, clientname, imagename):
-        self.dockerclient.containers.run(image=imagename,
+        self._dockerclient.containers.run(image=imagename,
                                     entrypoint="sleep",
                                     command=["356d"],
                                     name=clientname,
@@ -390,7 +390,7 @@ class Fuzzer(object):
 
     def kill_daemon(self, clientname):
         try:
-            c = self.dockerclient.containers.get(clientname)
+            c = self._dockerclient.containers.get(clientname)
             c.kill()
             c.stop()
         except Exception as e:
@@ -468,10 +468,10 @@ class Fuzzer(object):
 
     def start_processes(self, test):
 
-        starters = {'geth': Fuzzer.startGeth,
-                    'cpp': Fuzzer.startCpp,
-                    'parity': Fuzzer.startParity,
-                    'hera': Fuzzer.startHera}
+        starters = {'geth': self.startGeth,
+                    'cpp': self.startCpp,
+                    'parity': self.startParity,
+                    'hera': self.startHera}
 
         logger.info("Starting processes for %s on test %s" % (self._config.clientNames(), test.id()))
         # Start the processes
@@ -652,7 +652,7 @@ def main():
     ### setup cmdline parser
     parser = argparse.ArgumentParser(description='Ethereum consensus fuzzer')
     loglevels = ['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG', 'NOTSET']
-    parser.add_argument("-v", "--verbosity", default="critical",
+    parser.add_argument("-v", "--verbosity", default="info",
                       help="available loglevels: %s [default: %%default]" % ','.join(l.lower() for l in loglevels))
 
     # <required> configuration file: statetests.ini

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -4,31 +4,25 @@
 Executes state tests on multiple clients, checking for EVM trace equivalence
 
 """
-import json, sys, re, os, subprocess, io, itertools, traceback, time, collections, shutil
-from contextlib import redirect_stderr, redirect_stdout
+import json, sys, os, time, collections, shutil
+import argparse
+import select
+import docker
+import logging
 
 from evmlab import vm as VMUtils
 
-import docker
-dockerclient = docker.from_env()
-import select
-import logging
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-ch.setFormatter(formatter)
-logger.addHandler(ch)
 
 
-class Config():
+class Config(object):
 
-    def __init__(self, file = "statetests.ini"):
-        """Parses 'statetests.ini'-file, which 
+    def __init__(self, cmdline_args = None):
+        """Parses 'statetests.ini'-file, which
         may contain user-specific configuration
         """
+        self.cmdline_args = cmdline_args  # preserve cmdline args
+        file = self.cmdline_args.configfile
 
         import configparser, getpass
         config = configparser.ConfigParser()
@@ -42,11 +36,11 @@ class Config():
         for c in config[uname]['clients'].split(","):
             key = "{}.binary".format(c)
             if key in config[uname]:
-                self.active_clients.append((c , False, config[uname][key]))
+                self.active_clients.append((c, False, config[uname][key]))
             key = "{}.docker_name".format(c)
             if key in config[uname]:
-                self.active_clients.append((c , True, config[uname][key]))
-        
+                self.active_clients.append((c, True, config[uname][key]))
+
         self.fork_config = config[uname]['fork_config']
 
         def resolve(path):
@@ -58,17 +52,16 @@ class Config():
         # Artefacts are where stuff is stored
         self.artefacts = resolve(config[uname]['artefacts'])
         # temp paths is where we put stuff we don't necessarily save
-        self.temp_path  = resolve(config[uname]['tests_path'])
+        self.temp_path = resolve(config[uname]['tests_path'])
 
-        #here = os.path.dirname(os.path.realpath(__file__))
+        # here = os.path.dirname(os.path.realpath(__file__))
         self.host_id = "%s-%s-%d" % (uname, time.strftime("%a_%H_%M_%S"), os.getpid())
 
         logger.info("\n".join(self.info()))
 
-        os.makedirs(self.artefacts, exist_ok = True)
-        os.makedirs(self.testfilesPath(), exist_ok = True)
-        os.makedirs(self.logfilesPath(), exist_ok = True)
-
+        os.makedirs(self.artefacts, exist_ok=True)
+        os.makedirs(self.testfilesPath(), exist_ok=True)
+        os.makedirs(self.logfilesPath(), exist_ok=True)
 
     def testfilesPath(self):
         return "%s/testfiles/" % self.temp_path
@@ -77,13 +70,13 @@ class Config():
         return "%s/logs/" % self.temp_path
 
     def clientNames(self):
-        return [name for (name,y,z) in self.active_clients]
+        return [name for (name, y, z) in self.active_clients]
 
     def info(self):
         out = []
         out.append("Active clients:")
         for (name, isDocker, path) in self.active_clients:
-            out.append("  * {} : {} docker:{}".format(name, path, isDocker) )
+            out.append("  * {} : {} docker:{}".format(name, path, isDocker))
 
         out.append("Test generator: native (py)")
         out.append("Fork config:   %s" % self.fork_config)
@@ -93,11 +86,10 @@ class Config():
         out.append("Test files:    %s" % self.testfilesPath())
         return out
 
-cfg =Config('statetests.ini')
 
-class RawStateTest():
+class RawStateTest(object):
 
-    def __init__(self, statetest, identifier, filename):
+    def __init__(self, statetest, identifier, filename, config):
         self.identifier = identifier
         self._filename = filename
         self.statetest = statetest
@@ -105,6 +97,7 @@ class RawStateTest():
         self.procs = []
         self.traceFiles = []
         self.additionalArtefacts = []
+        self._config = config
 
     def filename(self):
         return self._filename
@@ -112,9 +105,8 @@ class RawStateTest():
     def id(self):
         return self.identifier
 
-
     def fullfilename(self):
-        return os.path.abspath("%s/%s" % (cfg.testfilesPath(),self.filename()))
+        return os.path.abspath("%s/%s" % (self._config.testfilesPath(),self.filename()))
 
     def writeToFile(self):
         # write to unique tmpfile
@@ -126,7 +118,7 @@ class RawStateTest():
         f = self.fullfilename()
         logger.info("Removing test artefacts %s" % ([f] + self.traceFiles))
         os.remove(f)
-        #delete non-failed traces
+        # delete non-failed traces
         for f in self.traceFiles:
             os.remove(f)
 
@@ -134,71 +126,72 @@ class RawStateTest():
         return "%s-%s.trace.log" % (self.identifier, client)
 
     def tempTraceLocation(self, client):
-        return os.path.abspath("%s/%s" % (cfg.logfilesPath(),self.tempTraceFilename(client)))
+        return os.path.abspath("%s/%s" % (self._config.logfilesPath(),self.tempTraceFilename(client)))
 
     def storeTrace(self, client, command):
         filename = self.tempTraceLocation(client)
-        logging.debug("%s full trace %s saved to %s" % (client, self.id(), filename ))
-#       Not needed when docker-processes write directly into files
-#        with open(filename, "w+") as f: 
-#            f.write("# command\n")
-#            f.write("# %s\n\n" % command)
-#            f.write(output)
-#
+        logging.debug("%s full trace %s saved to %s" % (client, self.id(), filename))
+        #       Not needed when docker-processes write directly into files
+        #        with open(filename, "w+") as f:
+        #            f.write("# command\n")
+        #            f.write("# %s\n\n" % command)
+        #            f.write(output)
+        #
         self.traceFiles.append(filename)
 
     def saveArtefacts(self):
         # Save the actual test json
-        saveloc = "%s/%s" % (cfg.artefacts, self.filename())
+        saveloc = "%s/%s" % (self._config.artefacts, self.filename())
         logger.info("Saving testcase as %s", saveloc)
-        shutil.move(self.fullfilename() , saveloc)
+        shutil.move(self.fullfilename(), saveloc)
 
         newTracefiles = []
 
         for f in self.traceFiles:
             fname = os.path.basename(f)
-            newloc = "%s/%s" % (cfg.artefacts,fname)
+            newloc = "%s/%s" % (self._config.artefacts,fname)
             logger.info("Saving trace as %s", newloc)
             shutil.move(f, newloc)
             newTracefiles.append(newloc)
-    
+
         self.traceFiles = newTracefiles
- 
+
     def addArtefact(self, fname, data):
-        fullpath = "%s/%s-%s" % (cfg.artefacts, self.id(), fname)
+        fullpath = "%s/%s-%s" % (self._config.artefacts, self.id(), fname)
         logger.info("Saving artefact %s", fullpath)
         with open(fullpath, "w+") as f:
-            f.write(data)    
+            f.write(data)
         self.additionalArtefacts.append(fullpath)
 
     def listArtefacts(self):
         return {
-            "id"   : self.id(),
-            "file" : self.filename(), 
+            "id": self.id(),
+            "file": self.filename(),
             "traces": [os.path.basename(f) for f in self.traceFiles],
-            "other" : [os.path.basename(f) for f in self.additionalArtefacts], 
+            "other": [os.path.basename(f) for f in self.additionalArtefacts],
         }
+
 
 class StateTest(RawStateTest):
     """ This class represents a single statetest, with a single post-tx result: one transaction
     executed on one single fork
     """
 
-    def __init__(self, statetest, counter, overwriteFork=True):
+    def __init__(self, statetest, counter, config, overwriteFork=True):
         self.number = None
-        identifier = "%s-%d" %(cfg.host_id, counter)
-        filename =  "%s-test.json" % identifier
-        super().__init__(statetest, identifier, filename)
+        identifier = "%s-%d" %(config.host_id, counter)
+        filename = "%s-test.json" % identifier
+        super().__init__(statetest, identifier, filename, config=config)
 
 
         if overwriteFork and "Byzantium" in statetest['randomStatetest']['post'].keys():
             # Replace the fork with what we are currently configured for
             postState = statetest['randomStatetest']['post'].pop('Byzantium')
-            statetest['randomStatetest']['post'][cfg.fork_config] = postState 
+            statetest['randomStatetest']['post'][self._config.fork_config] = postState
 
 
-        # Replace the top level name 'randomStatetest' with something meaningful (same as filename)        
-        statetest['randomStatetest%s' % self.identifier] =statetest.pop('randomStatetest', None) 
+            # Replace the top level name 'randomStatetest' with something meaningful (same as filename)
+        statetest['randomStatetest%s' % self.identifier] = statetest.pop('randomStatetest', None)
 
         self.statetest = statetest
         self.canon_traces = []
@@ -207,302 +200,31 @@ class StateTest(RawStateTest):
         self.additionalArtefacts = []
 
 
-def generateTests():
-    """This method produces json-files, each containing one statetest, with _one_ poststate. 
-    It stores each test with a filename that is unique per user and per process, so that two
-    paralell executions should not interfere with eachother. 
-    
-    returns (filename, object) 
-    """
+class TestExecutor(object):
 
-    from evmlab.tools.statetests import templates
-    from evmlab.tools.statetests import randomtest
+    def __init__(self, fuzzer):
+        self._fuzzer = fuzzer
 
-    t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
-    test = {}
-    counter = 0
-
-    while True: 
-        test.update(t)
-        test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
-        s = StateTest(test_obj, counter)
-        counter = counter +1
-        yield s
-
-
-def get_summary(combined_trace, n=20):
-    """Returns (up to) n (default 20) preceding steps before the first diff, and the diff-section
-    """
-    from collections import deque
-    buf = deque([],n)
-    index = 0
-    for index, line in enumerate(combined_trace):
-        if line.startswith("[!!]"):
-            buf.append("\n---- [ %d steps in total before diff ]-------\n\n" % (index))
-            break
-        buf.append(line)
-
-    for i in range(index, min(len(combined_trace), index+5 )):
-        buf.append(combined_trace[i])
-
-    return list(buf)
-
-def startDaemon(clientname, imagename):
-    dockerclient.containers.run(image = imagename, 
-        entrypoint="sleep",
-        command = ["356d"],
-        name=clientname,
-        detach=True, 
-        remove=True,
-        volumes={
-            cfg.testfilesPath():{ 'bind':'/testfiles/', 'mode':"rw"},
-            cfg.logfilesPath():{ 'bind':'/logs/', 'mode':"rw"},
-            })
-
-    logger.info("Started docker daemon %s %s" % (imagename, clientname))
-
-def killDaemon(clientname):
-    try:
-        c = dockerclient.containers.get(clientname)
-        c.kill()
-        c.stop()
-    except Exception as e:
-        pass
-
- #   VMUtils.finishProc(VMUtils.startProc(["docker", "kill",clientname]))
-
-def startDaemons():
-    """ startDaemons starts docker processes for all clients. The actual execution of 
-    testcases is then performed via docker exec. Means that executing a specific testcase
-    does not require starting a whole new docker context, instead we just reuse the existing
-    docker process. 
-    The startDaemon basically does this: 
-
-    ```
-    docker run ethereum/client-go:alltools-latest sleep 356d    
-    ```
-
-    """
-
-    daemons = []
-    #Start the processes
-    for (client_name, isDocker, cmd) in cfg.active_clients:
-        if isDocker:
-            logger.info("Starting daemon for %s : %s", client_name, cmd)
-            # First, kill off any existing daemons
-            killDaemon(client_name)
-            procinfo = startDaemon(client_name, cmd)
-            daemons.append( (procinfo, client_name ))        
-        else:
-            logger.warning("Not a docker client %s",client_name)
-
-
-
-def execInDocker(name, cmd, stdout = True, stderr=True):
-    start_time = time.time()
-    
-    # For now, we need to disable stream, since otherwise the stderr and stdout 
-    # gets mixed, which causes false positives. 
-    # This really is a bottleneck, since it means all execution will be serial instead
-    # of paralell, and makes it really slow. The fix is either to fix the python docker
-    # api, or make sure that parity also prints the stateroot on stderr, which currently
-    # can only be read from stdout. 
-
-    # Update, now using socket, with 1>&2 (piping stdout into stderr)
-    stream = False
-    socket = True
-    #logger.info("executing in %s: %s" %  (name," ".join(cmd)))
-    container = dockerclient.containers.get(name)
-    (exitcode, output) = container.exec_run(cmd, stream=stream, socket = socket, stdout=stdout, stderr = stderr)     
-    
-    retval = {'cmd':" ".join(cmd)}
-
-    # If stream is False, then docker soups up the output, and we just decode it once
-    # when the caller wants it
-    
-    if socket:
-        retval['output'] = output 
-    elif stream:
-        # If the stream is True, then we need to iterate over output, 
-        # and decode each chunk
-        retval['output'] = lambda: "".join([chunk.decode() for chunk in output])
-    else:
-        # If we're waiting for the output, just return the decoded immediately
-        retval['output'] =lambda: output.decode()
-
-    return retval
-    
-
-def shWrap(cmd, output):
-    """ Wraps a command in /bin/sh, with output to the given file"""
-    return ["/bin/sh","-c"," ".join(cmd) + " &> /logs/%s" % output]
-
-
-def startGeth(test):
-    """
-    With daemonized docker images, we execute basically the following
-
-    docker exec -it ggeth2 evm --json --code "6060" run
-    or
-    docker exec -it <name> <command>
-
-    """
-    cmd = ["evm","--json","--nomemory","statetest","/testfiles/%s" % os.path.basename(test.filename())]
-    cmd = shWrap(cmd, test.tempTraceFilename('geth'))
-    return execInDocker("geth", cmd, stdout = False)
-
-
-def startParity(test):
-    cmd = ["/parity-evm","state-test", "--std-json","/testfiles/%s" % os.path.basename(test.filename())]
-    #cmd = ["/bin/sh","-c","/parity-evm state-test --std-json /testfiles/%s 1>&2" % os.path.basename(test.filename())]
-    cmd = shWrap(cmd,test.tempTraceFilename('parity'))
-    return execInDocker("parity", cmd)
-
-def startHera(test):
-    cmd = [ "/build/test/testeth", 
-            "-t","GeneralStateTests","--",
-            "--vm", "hera",
-            "--evmc", "evm2wasm.js=true", "--evmc", "fallback=false",
-            "--singletest", "/testfiles/%s" % os.path.basename(test.tmpfile), test.name,
-            ]
-    return execInDocker("hera", cmd, stderr=False)
-
-def startCpp(test):
-    
-    #docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0001--randomStatetestmartin-Fri_09_42_57-7812-0-1-test.json randomStatetestmartin-Fri_09_42_57-7812-0   --jsontrace '{ "disableStorage" : false, "disableMemory" : false, "disableStack" : false, "fullStorage" : true }' 
-    #docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0015--randomStatetestmartin-Fri_10_15_53-13070-3-3-test.json randomStatetestmartin-Fri_10_15_53-13070-3 --jsontrace '{"disableStack": false, "fullStorage": false, "disableStorage": false, "disableMemory": false}'
-
-    cmd = ["/usr/bin/testeth",
-            "-t","GeneralStateTests","--",
-            "--singletest", "/testfiles/%s" % os.path.basename(test.tmpfile), test.name,
-            "--jsontrace", "'%s'" % json.dumps({"disableStorage": True, "disableMemory": True, "disableStack": False, "fullStorage": False}) 
-            ]
-    return execInDocker("cpp", cmd, stderr=False)
-
-
-def start_processes(test):
-
-    starters = {'geth': startGeth, 'cpp': startCpp, 'parity': startParity, 'hera': startHera}
-
-    logger.info("Starting processes for %s on test %s" % ( cfg.clientNames(), test.id()))
-    #Start the processes
-    for (client_name, x, y) in cfg.active_clients:
-        if client_name in starters.keys():
-            procinfo = starters[client_name](test)
-            test.procs.append( (procinfo, client_name ))        
-        else:
-            logger.warning("Undefined client %s", client_name)
-
-
-canonicalizers = {
-    "geth" : VMUtils.GethVM.canonicalized, 
-    "cpp"  : VMUtils.CppVM.canonicalized, 
-    "py"   : VMUtils.PyVM.canonicalized, 
-    "parity"  :  VMUtils.ParityVM.canonicalized ,
-    "hera" : VMUtils.HeraVM.canonicalized,
-}
-
-
-
-def end_processes(test):
-    """ End processes for the given test, slurp up the output and compare the traces
-    returns the length of the canon-trace emitted (or -1)
-    """
-    # Handle the old processes
-    if test is None: 
-        return None
-    tracelen = 0
-    canon_steps = None
-    canon_trace = []
-    first = True
-    stats = VMUtils.Stats()
-    for (proc_info, client_name) in test.procs:
-        t1 = time.time()
-        test.storeTrace(client_name, proc_info['cmd'])
-        canonicalizer = canonicalizers[client_name]
-        canon_steps = []
-        with open(test.tempTraceLocation(client_name)) as output:
-            canon_step_generator = canonicalizer(output)
-            stat_generator = stats.traceStats(canon_step_generator)
-            canon_trace = [VMUtils.toText(step) for step in stat_generator]
-        stats.stop()
-        test.canon_traces.append(canon_trace)
-        tracelen = len(canon_trace)
-        t2 = time.time()
-        logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms" 
-            % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))
-
-
-    #print(stats)
-    #print(canon_steps)
-    #print("\n".join(canon_trace))
-    return (tracelen, stats.result())
-
-def processTraces(test, forceSave=False):
-    if test is None:
-        return None
-
-    # Process previous traces
-
-    (equivalent, trace_output) = VMUtils.compare_traces(test.canon_traces, cfg.clientNames()) 
-
-    if equivalent and not forceSave:
-        test.removeFiles()
-        return None
-    
-    if not equivalent:
-        logger.warning("CONSENSUS BUG!!!")
-
-    trace_summary = get_summary(trace_output)
-    # save the state-test
-    test.saveArtefacts()
-    # save combined trace and abbreviated trace
-    test.addArtefact("combined_trace.log","\n".join(trace_output))
-    test.addArtefact("shortened_trace.log","\n".join(trace_summary))
-
-    return test
-
-def event_str(event):
-    r = []
-    if event & select.POLLIN:
-        r.append('IN')
-    if event & select.POLLOUT:
-        r.append('OUT')
-    if event & select.POLLPRI:
-        r.append('PRI')
-    if event & select.POLLERR:
-        r.append('ERR')
-    if event & select.POLLHUP:
-        r.append('HUP')
-    if event & select.POLLNVAL:
-        r.append('NVAL')
-    return ' '.join(r) 
-
-class TestExecutor():
-
-    def __init__(self):
-        
         self.stats = {
-            "pass_count" : 0,
-            "fail_count" : 0,
-            "start_time" : time.time(),
-            "total_count" : 0, 
-            "num_active_tests": 0, 
+            "pass_count": 0,
+            "fail_count": 0,
+            "start_time": time.time(),
+            "total_count": 0,
+            "num_active_tests": 0,
             "num_active_sockets": 0,
         }
         self.failures = []
-        self.traceLengths = collections.deque([],100)
+        self.traceLengths = collections.deque([], 100)
         self.traceDepths = collections.deque([], 100)
         self.traceConstantinopleOps = collections.deque([], 100)
 
     def onPass(self):
-        self.stats["pass_count"] = self.stats["pass_count"] +1
-        self.stats["total_count"] = self.stats["total_count"]+1
-
+        self.stats["pass_count"] = self.stats["pass_count"] + 1
+        self.stats["total_count"] = self.stats["total_count"] + 1
 
     def onFail(self, testcase):
-        self.stats["fail_count"] = self.stats["fail_count"] +1
-        self.stats["total_count"] = self.stats["total_count"]+1
+        self.stats["fail_count"] = self.stats["fail_count"] + 1
+        self.stats["total_count"] = self.stats["total_count"] + 1
         self.failures.append(failingTestcase.listArtefacts())
 
     def numFails(self):
@@ -521,7 +243,7 @@ class TestExecutor():
         # End previous procs
         if test is None:
             return
-        data = end_processes(test)
+        data = self._fuzzer.end_processes(test)
         if data is not None:
             (traceLength, stats) = data
             self.traceLengths.append(traceLength)
@@ -529,7 +251,7 @@ class TestExecutor():
             self.traceConstantinopleOps.append(stats['constatinopleOps'])
 
         # Process previous traces
-        failingTestcase = processTraces(test, forceSave = False)
+        failingTestcase = self._fuzzer.processTraces(test, forceSave = False)
         if failingTestcase is None:
             self.onPass()
         else:
@@ -538,28 +260,28 @@ class TestExecutor():
         if reporting:
             # Do some reporting
             logger.info("Fails: {}, Pass: {}, #test {} speed: {:f} tests/s".format(
-                    self.numFails(), self.numPass(), self.numTotals(),self.testsPerSecond()
-                ))
+                self.numFails(), self.numPass(), self.numTotals(), self.testsPerSecond()
+            ))
 
-    def startFuzzing(self):   
+    def startFuzzing(self):
         self.stats["start_time"] = time.time()
         # This is the max cap of paralellism, it's just to prevent
         # things going out of hand if tests start piling up
         # We don't expect to actually reach it
         MAX_PARALELL = 50
-        # The poller which we use, to register our 
+        # The poller which we use, to register our
         # processes IO channels on
         poller = select.poll()
         active_sockets = {}
 
         # The poll-mask. We listen to everything, except 'ready to write'
-        mask = select.POLLIN|select.POLLPRI| select.POLLERR| select.POLLHUP|select.POLLNVAL
+        mask = select.POLLIN | select.POLLPRI | select.POLLERR | select.POLLHUP | select.POLLNVAL
 
-        for test in generateTests():
+        for test in self._fuzzer.generate_tests():
             if self.stats["num_active_tests"] < MAX_PARALELL:
                 test.writeToFile()
                 # Start new procs
-                start_processes(test)
+                self._fuzzer.start_processes(test)
                 self.stats["num_active_tests"] = self.stats["num_active_tests"] + 1
                 self.stats["num_active_sockets"] = len(active_sockets.keys())
                 # Put the new test to the first position
@@ -581,12 +303,12 @@ class TestExecutor():
                 continue
             for (socket, event) in socketlist:
                 # At least one process for this test is finished
-                
-                # Stop listeninng to this socket                
+
+                # Stop listeninng to this socket
                 poller.unregister(socket)
                 # Find the test
-                test  = active_sockets.pop(socket)
-                test.numprocs = test.numprocs-1
+                test = active_sockets.pop(socket)
+                test.numprocs = test.numprocs - 1
                 if test.numprocs == 0:
                     logger.info("All procs finished for test %s" % test.id())
                     self.stats["num_active_tests"] = self.stats["num_active_tests"] - 1
@@ -596,39 +318,27 @@ class TestExecutor():
         import collections, statistics
         from datetime import datetime
         return {
-            "starttime" : datetime.utcfromtimestamp(self.stats["start_time"]).strftime('%Y-%m-%d %H:%M:%S'),
-            "pass" : self.numPass(), 
-            "fail" : self.numFails(),
-            "failures" : self.failures,
-            "speed" : self.testsPerSecond(),
-            "mean" : statistics.mean(self.traceLengths) if self.traceLengths else "NA",
-            "stdev" : statistics.stdev(self.traceLengths) if len(self.traceLengths) >2 else "NA",
-            "numZero" : self.traceLengths.count(0) if self.traceLengths else "NA" ,
-            "max" : max(self.traceLengths) if self.traceLengths else "NA",
-            "maxDepth" : max(self.traceDepths) if self.traceDepths else "NA",
-            "numConst" : statistics.mean(self.traceConstantinopleOps) if self.traceConstantinopleOps else "NA",
+            "starttime": datetime.utcfromtimestamp(self.stats["start_time"]).strftime('%Y-%m-%d %H:%M:%S'),
+            "pass": self.numPass(),
+            "fail": self.numFails(),
+            "failures": self.failures,
+            "speed": self.testsPerSecond(),
+            "mean": statistics.mean(self.traceLengths) if self.traceLengths else "NA",
+            "stdev": statistics.stdev(self.traceLengths) if len(self.traceLengths) > 2 else "NA",
+            "numZero": self.traceLengths.count(0) if self.traceLengths else "NA",
+            "max": max(self.traceLengths) if self.traceLengths else "NA",
+            "maxDepth": max(self.traceDepths) if self.traceDepths else "NA",
+            "numConst": statistics.mean(self.traceConstantinopleOps) if self.traceConstantinopleOps else "NA",
             "activeSockets": self.stats["num_active_sockets"],
             "activeTests": self.stats["num_active_tests"],
         }
 
-def testSummary():
-    """Enable this, and test by passing a trace-output via console"""
-    with open(sys.argv[1]) as f:
-        print("".join(get_summary(f.readlines())))
-
-def main():
-    # Start all docker daemons that we'll use during the execution
-    startDaemons()
-
-    TestExecutor().startFuzzing()
-
-
 def testSpeedGenerateTests():
-    """This method produces json-files, each containing one statetest, with _one_ poststate. 
+    """This method produces json-files, each containing one statetest, with _one_ poststate.
     It stores each test with a filename that is unique per user and per process, so that two
-    paralell executions should not interfere with eachother. 
-    
-    returns (filename, object) 
+    paralell executions should not interfere with eachother.
+
+    returns (filename, object)
     """
 
     from evmlab.tools.statetests import templates
@@ -639,15 +349,339 @@ def testSpeedGenerateTests():
     test.update(t)
     counter = 0
     start = time.time()
-    while True: 
+    while True:
         x0 = time.time()
-        #test.update(t)
+        # test.update(t)
         test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
         x = str(test_obj)
         print(test_obj["randomStatetest"]["transaction"]["to"])
         x1 = time.time()
-        print("%d %f (tot %f/s)" % (counter, x1 - x0, counter / (x1 - start) ))
-        counter = counter +1
+        print("%d %f (tot %f/s)" % (counter, x1 - x0, counter / (x1 - start)))
+        counter = counter + 1
+
+
+class Fuzzer(object):
+
+    canonicalizers = {
+        "geth": VMUtils.GethVM.canonicalized,
+        "cpp": VMUtils.CppVM.canonicalized,
+        "py": VMUtils.PyVM.canonicalized,
+        "parity": VMUtils.ParityVM.canonicalized,
+        "hera": VMUtils.HeraVM.canonicalized,
+    }
+
+    def __init__(self, config=None):
+        self._config = config
+
+        self._dockerclient = docker.from_env()
+
+    def start_daemons(self):
+        """ startDaemons starts docker processes for all clients. The actual execution of
+        testcases is then performed via docker exec. Means that executing a specific testcase
+        does not require starting a whole new docker context, instead we just reuse the existing
+        docker process.
+        The startDaemon basically does this:
+
+        ```
+        docker run ethereum/client-go:alltools-latest sleep 356d
+        ```
+
+        """
+
+        daemons = []
+        # Start the processes
+        for (client_name, isDocker, cmd) in self._config.active_clients:
+            if isDocker:
+                logger.info("Starting daemon for %s : %s", client_name, cmd)
+                # First, kill off any existing daemons
+                self.kill_daemon(client_name)
+                procinfo = self.start_daemon(client_name, cmd)
+                daemons.append((procinfo, client_name))
+            else:
+                logger.warning("Not a docker client %s", client_name)
+
+    def start_daemon(self, clientname, imagename):
+        self.dockerclient.containers.run(image=imagename,
+                                    entrypoint="sleep",
+                                    command=["356d"],
+                                    name=clientname,
+                                    detach=True,
+                                    remove=True,
+                                    volumes={
+                                        self._config.testfilesPath(): {'bind': '/testfiles/', 'mode': "rw"},
+                                        self._config.logfilesPath(): {'bind': '/logs/', 'mode': "rw"},
+                                    })
+
+        logger.info("Started docker daemon %s %s" % (imagename, clientname))
+
+    def kill_daemon(self, clientname):
+        try:
+            c = self.dockerclient.containers.get(clientname)
+            c.kill()
+            c.stop()
+        except Exception as e:
+            pass
+
+    #   VMUtils.finishProc(VMUtils.startProc(["docker", "kill",clientname]))
+
+    def generate_tests(self):
+        """This method produces json-files, each containing one statetest, with _one_ poststate.
+        It stores each test with a filename that is unique per user and per process, so that two
+        paralell executions should not interfere with eachother.
+
+        returns (filename, object)
+        """
+
+        from evmlab.tools.statetests import templates
+        from evmlab.tools.statetests import randomtest
+
+        t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
+        test = {}
+        counter = 0
+
+        while True:
+            test.update(t)
+            test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
+            s = StateTest(test_obj, counter, config=self._config)
+            counter = counter + 1
+            yield s
+
+    def processTraces(self, test, forceSave=False):
+        if test is None:
+            return None
+
+        # Process previous traces
+
+        (equivalent, trace_output) = VMUtils.compare_traces(test.canon_traces, self._config.clientNames())
+
+        if equivalent and not forceSave:
+            test.removeFiles()
+            return None
+
+        if not equivalent:
+            logger.warning("CONSENSUS BUG!!!")
+
+        trace_summary = self.get_summary(trace_output)
+        # save the state-test
+        test.saveArtefacts()
+        # save combined trace and abbreviated trace
+        test.addArtefact("combined_trace.log", "\n".join(trace_output))
+        test.addArtefact("shortened_trace.log", "\n".join(trace_summary))
+
+        return test
+
+    def get_summary(self, combined_trace, n=20):
+        """Returns (up to) n (default 20) preceding steps before the first diff, and the diff-section
+        """
+        from collections import deque
+        buf = deque([], n)
+        index = 0
+        for index, line in enumerate(combined_trace):
+            if line.startswith("[!!]"):
+                buf.append("\n---- [ %d steps in total before diff ]-------\n\n" % (index))
+                break
+            buf.append(line)
+
+        for i in range(index, min(len(combined_trace), index + 5)):
+            buf.append(combined_trace[i])
+
+        return list(buf)
+
+    def testSummary(self):
+        """Enable this, and test by passing a trace-output via console"""
+        with open(sys.argv[1]) as f:
+            print("".join(self.get_summary(f.readlines())))
+
+    def start_processes(self, test):
+
+        starters = {'geth': Fuzzer.startGeth,
+                    'cpp': Fuzzer.startCpp,
+                    'parity': Fuzzer.startParity,
+                    'hera': Fuzzer.startHera}
+
+        logger.info("Starting processes for %s on test %s" % (self._config.clientNames(), test.id()))
+        # Start the processes
+        for (client_name, x, y) in self._config.active_clients:
+            if client_name in starters.keys():
+                procinfo = starters[client_name](test)
+                test.procs.append((procinfo, client_name))
+            else:
+                logger.warning("Undefined client %s", client_name)
+
+    def end_processes(self, test):
+        """ End processes for the given test, slurp up the output and compare the traces
+        returns the length of the canon-trace emitted (or -1)
+        """
+        # Handle the old processes
+        if test is None:
+            return None
+        tracelen = 0
+        canon_steps = None
+        canon_trace = []
+        first = True
+        stats = VMUtils.Stats()
+        for (proc_info, client_name) in test.procs:
+            t1 = time.time()
+            test.storeTrace(client_name, proc_info['cmd'])
+            canonicalizer = self.canonicalizers[client_name]
+            canon_steps = []
+            with open(test.tempTraceLocation(client_name)) as output:
+                canon_step_generator = canonicalizer(output)
+                stat_generator = stats.traceStats(canon_step_generator)
+                canon_trace = [VMUtils.toText(step) for step in stat_generator]
+            stats.stop()
+            test.canon_traces.append(canon_trace)
+            tracelen = len(canon_trace)
+            t2 = time.time()
+            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms"
+                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))
+
+        # print(stats)
+        # print(canon_steps)
+        # print("\n".join(canon_trace))
+        return (tracelen, stats.result())
+
+    def execInDocker(self, name, cmd, stdout=True, stderr=True):
+        start_time = time.time()
+
+        # For now, we need to disable stream, since otherwise the stderr and stdout
+        # gets mixed, which causes false positives.
+        # This really is a bottleneck, since it means all execution will be serial instead
+        # of paralell, and makes it really slow. The fix is either to fix the python docker
+        # api, or make sure that parity also prints the stateroot on stderr, which currently
+        # can only be read from stdout.
+
+        # Update, now using socket, with 1>&2 (piping stdout into stderr)
+        stream = False
+        socket = True
+        # logger.info("executing in %s: %s" %  (name," ".join(cmd)))
+        container = self._dockerclient.containers.get(name)
+        (exitcode, output) = container.exec_run(cmd, stream=stream, socket=socket, stdout=stdout, stderr=stderr)
+
+        retval = {'cmd': " ".join(cmd)}
+
+        # If stream is False, then docker soups up the output, and we just decode it once
+        # when the caller wants it
+
+        if socket:
+            retval['output'] = output
+        elif stream:
+            # If the stream is True, then we need to iterate over output,
+            # and decode each chunk
+            retval['output'] = lambda: "".join([chunk.decode() for chunk in output])
+        else:
+            # If we're waiting for the output, just return the decoded immediately
+            retval['output'] = lambda: output.decode()
+
+        return retval
+
+    @staticmethod
+    def shWrap(cmd, output):
+        """ Wraps a command in /bin/sh, with output to the given file"""
+        return ["/bin/sh", "-c", " ".join(cmd) + " &> /logs/%s" % output]
+
+    def startGeth(self, test):
+        """
+        With daemonized docker images, we execute basically the following
+
+        docker exec -it ggeth2 evm --json --code "6060" run
+        or
+        docker exec -it <name> <command>
+
+        """
+        cmd = ["evm", "--json", "--nomemory", "statetest", "/testfiles/%s" % os.path.basename(test.filename())]
+        cmd = Fuzzer.shWrap(cmd, test.tempTraceFilename('geth'))
+        return self.execInDocker("geth", cmd, stdout=False)
+
+    def startParity(self, test):
+        cmd = ["/parity-evm", "state-test", "--std-json", "/testfiles/%s" % os.path.basename(test.filename())]
+        # cmd = ["/bin/sh","-c","/parity-evm state-test --std-json /testfiles/%s 1>&2" % os.path.basename(test.filename())]
+        cmd = Fuzzer.shWrap(cmd, test.tempTraceFilename('parity'))
+        return self.execInDocker("parity", cmd)
+
+    def startHera(self, test):
+        cmd = ["/build/test/testeth",
+               "-t", "GeneralStateTests", "--",
+               "--vm", "hera",
+               "--evmc", "evm2wasm.js=true", "--evmc", "fallback=false",
+               "--singletest", "/testfiles/%s" % os.path.basename(test.tmpfile), test.name,
+               ]
+        return self.execInDocker("hera", cmd, stderr=False)
+
+    def startCpp(self, test):
+        # docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0001--randomStatetestmartin-Fri_09_42_57-7812-0-1-test.json randomStatetestmartin-Fri_09_42_57-7812-0   --jsontrace '{ "disableStorage" : false, "disableMemory" : false, "disableStack" : false, "fullStorage" : true }'
+        # docker exec -it cpp /usr/bin/testeth -t GeneralStateTests -- --singletest /testfiles/0015--randomStatetestmartin-Fri_10_15_53-13070-3-3-test.json randomStatetestmartin-Fri_10_15_53-13070-3 --jsontrace '{"disableStack": false, "fullStorage": false, "disableStorage": false, "disableMemory": false}'
+
+        cmd = ["/usr/bin/testeth",
+               "-t", "GeneralStateTests", "--",
+               "--singletest", "/testfiles/%s" % os.path.basename(test.tmpfile), test.name,
+               "--jsontrace", "'%s'" % json.dumps(
+                {"disableStorage": True, "disableMemory": True, "disableStack": False, "fullStorage": False})
+               ]
+        return self.execInDocker("cpp", cmd, stderr=False)
+
+
+def event_str(event):
+    r = []
+    if event & select.POLLIN:
+        r.append('IN')
+    if event & select.POLLOUT:
+        r.append('OUT')
+    if event & select.POLLPRI:
+        r.append('PRI')
+    if event & select.POLLERR:
+        r.append('ERR')
+    if event & select.POLLHUP:
+        r.append('HUP')
+    if event & select.POLLNVAL:
+        r.append('NVAL')
+    return ' '.join(r)
+
+
+def main():
+    # setup logging
+    logger.setLevel(logging.DEBUG)
+
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    # argparsing
+    parser = argparse.ArgumentParser(description='Ethereum consensus fuzzer')
+    loglevels = ['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG', 'NOTSET']
+    parser.add_argument("-v", "--verbosity", default="critical",
+                      help="available loglevels: %s [default: %%default]" % ','.join(l.lower() for l in loglevels))
+
+    # <required> configuration file: statetests.ini
+    parser.add_argument("-c", "--configfile", default="statetests.ini", required=True,
+                        help="path to configuration file (statetests.ini)")
+
+    # TODO: <optional> evmcode generation settings
+    grp_evmcodegen = parser.add_argument_group('EVM CodeGeneration Settings')
+    #grp_evmcodegen.add_option("-g", "--codegen", default="", help="select the evm code generation engine to be used")
+    #grp_evmcodegen.add_option("-w", "--weights", default="", help="")
+
+    # parse args
+    (options, args) = parser.parse_args()
+
+    if options.verbosity.upper() in loglevels:
+        options.verbosity = getattr(logging, options.verbosity.upper())
+        logger.setLevel(options.verbosity)
+    else:
+        parser.error("invalid verbosity selected. please check --help")
+
+
+    # TODO: MERGE statetests.ini and cmdline settings into one settings object and propagate it to all other classes.
+    #       merge within Config() and make it always return sane settings or raise exceptions on conflicts
+
+    fuzzer = Fuzzer(config=Config(options))  # fix interface for config (only provide options and
+
+    # Start all docker daemons that we'll use during the execution
+    fuzzer.start_daemons()
+
+    TestExecutor(fuzzer=fuzzer).startFuzzing()
 
 
 if __name__ == '__main__':

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -251,7 +251,7 @@ class TestExecutor(object):
             self.traceConstantinopleOps.append(stats['constatinopleOps'])
 
         # Process previous traces
-        failingTestcase = self._fuzzer.processTraces(test, forceSave = False)
+        failingTestcase = self._fuzzer.processTraces(test, forceSave = self._fuzzer._config.cmdline_args.force_save)
         if failingTestcase is None:
             self.onPass()
         else:
@@ -650,17 +650,21 @@ def main():
     logger.addHandler(ch)
 
     ### setup cmdline parser
-    parser = argparse.ArgumentParser(description='Ethereum consensus fuzzer')
+    parser = argparse.ArgumentParser(description='Ethereum consensus fuzzer',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     loglevels = ['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'WARN', 'INFO', 'DEBUG', 'NOTSET']
     parser.add_argument("-v", "--verbosity", default="info",
-                      help="available loglevels: %s [default: %%default]" % ','.join(l.lower() for l in loglevels))
+                      help="available loglevels: %s" % ','.join(l.lower() for l in loglevels))
 
     # <required> configuration file: statetests.ini
     parser.add_argument("-c", "--configfile", default="statetests.ini", required=True,
-                        help="path to configuration file (statetests.ini)")
+                        help="path to configuration file")
+
+    grp_artefacts = parser.add_argument_group('Configure Output Artefacts')
+    grp_artefacts.add_argument("-x", "--force-save", action="store_true", help="Keep tracefiles/logs/testfiles for non-failing testcases (watch disk space!)")
 
     # TODO: <optional> evmcode generation settings
-    grp_evmcodegen = parser.add_argument_group('EVM CodeGeneration Settings')
+    #grp_evmcodegen = parser.add_argument_group('EVM CodeGeneration Settings')
     #grp_evmcodegen.add_option("-g", "--codegen", default="", help="select the evm code generation engine to be used")
     #grp_evmcodegen.add_option("-w", "--weights", default="", help="")
 


### PR DESCRIPTION
I've quickly refactored `fuzzer.py`. no original code was omitted. Most of the methods are now part of the new `Fuzzer()` class (together with `TestExecution` the entry class for fuzzing. see `def main`)

- [x] moved methods to new `Fuzzer()` class. Hierarchy: `TestExecutor() <-- Fuzzer() <-- Config(cmdline and statetests.ini)`
- [x] added argparse for cmdline parsing 
- [x] added cmdline `--config <statetests.ini>` and `--force-save` to force saving of testcase/trace/logfiles and `--enable-reporting` to switch on testrun reporting
- [x] checked if fuzzer is still working as expected - looks good
- [x] implement configuration merging (take cmdline args and merge them into `Config()` and use `Config()` as the central configuration container  (this is very hacky: see `Config._merge_cmdline_args()`. Cmdline overrides statetests.ini.

once this is merged we can easily add new configurative options (like evmcodegen selection, etc.) (see #91)

**the --config option is mandatory**
```
python utilities/fuzzer.py -c statetests.ini
```

**usage**
```
python utilities/fuzzer.py --help
usage: fuzzer.py [-h] [-v VERBOSITY] -c CONFIGFILE [-x] [-r]

Ethereum consensus fuzzer

optional arguments:
  -h, --help            show this help message and exit
  -v VERBOSITY, --verbosity VERBOSITY
                        available loglevels:
                        critical,fatal,error,warning,warn,info,debug,notset
  -c CONFIGFILE, --configfile CONFIGFILE
                        path to configuration file (default: statetests.ini)

Configure Output Artefacts and Reporting:
  -x, --force-save      Keep tracefiles/logs/testfiles for non-failing
                        testcases (watch disk space!) (default: False)
  -r, --enable-reporting
                        Output testrun statistics (num of passes/fails and
                        speed (default: False)
```
