### PR TITLE
clean up after run

### DIFF
--- a/evmlab/vm.py
+++ b/evmlab/vm.py
@@ -75,6 +75,12 @@ def toText(op):
         else:
             opname = "UNKNOWN"
         op['opname'] = opname
+
+        if 'stack' in op.keys():
+            stack = op['stack']
+            if len(stack) > 6:
+                _st = "... {}".format(stack[-4:])
+                op['stack'] = _st
         return "pc {pc:>5} op {opname:>10}({op:>3}) gas {gas:>8} depth {depth:>2} stack {stack}".format(**op)
     elif 'stateRoot' in op.keys():
         return "stateRoot {}".format(op['stateRoot'])

--- a/sstore_fun.py
+++ b/sstore_fun.py
@@ -1,0 +1,64 @@
+"""
+This program generats a piece of bytecode which 
+
+1. Assumes that slot 1 has non-zero value of '2'
+2. Overwrites slot 1 with '0'
+3. Calls itself
+  3.1 Overwrites slot '1' with '3'
+  3.2 stop
+4. stop
+
+The step in 3.1 should decrease the refund counter with 15k
+
+This program reproduces the flaw that parity and aleth had concerning
+negative-valued refund counters in different call contexts
+"""
+#!/usr/bin/env python
+
+import json
+import tempfile, os
+from evmlab import compiler as c
+from evmlab import vm
+from evmlab import genesis
+
+def generateCall():
+
+    def sstore(k, v):
+        p.push(v).push(k).op(c.SSTORE)
+
+    label = 21
+    p = c.Program()
+    # Check if we're calling ourself:
+    p.op(c.CALLER) #0
+    p.op(c.ADDRESS)#1
+    p.op(c.EQ)     #2
+    # Yes, we are, go to 3
+    p.push(label)  
+    p.op(c.JUMPI) 
+    # No, this is first call
+    sstore(1,0) # Set slot 1 to 0
+
+    # Do the call
+    p.push(0)        # outsize 
+    p.op(c.DUP1)     # out
+    p.op(c.DUP1)     # insize
+    p.op(c.DUP1)     # instart 
+    p.op(c.DUP1)     # value 
+    p.op(c.ADDRESS)  # address
+    p.op(c.GAS)      # gas
+    p.op(c.CALL)     #
+    p.op(c.STOP)     # 
+
+    #This is 3.1
+    p.op(c.JUMPDEST) # posotion 21
+    # Set slot 
+    sstore(1,3)    
+    p.op(c.STOP)
+    return p.bytecode()
+
+
+def main():
+    print("0x%s" % generateCall())
+
+if __name__ == '__main__':
+    main()

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -123,15 +123,11 @@ class RawStateTest():
             json.dump(self.statetest, outfile)
 
     def removeFiles(self):
-        if True:
-            return
         f = self.fullfilename()
-        logger.debug("Removing test file %s" % f)
+        logger.info("Removing test artefacts %s" % ([f] + self.traceFiles))
         os.remove(f)
-
         #delete non-failed traces
         for f in self.traceFiles:
-            logger.debug("Removing trace file %s" % f)
             os.remove(f)
 
     def tempTraceFilename(self, client):
@@ -143,6 +139,7 @@ class RawStateTest():
     def storeTrace(self, client, output, command):
         filename = self.tempTraceLocation(client)
         logging.debug("%s full trace %s saved to %s" % (client, self.id(), filename ))
+#       Not needed when docker-processes write directly into files
 #        with open(filename, "w+") as f: 
 #            f.write("# command\n")
 #            f.write("# %s\n\n" % command)


### PR DESCRIPTION
Fixes https://github.com/ethereum/evmlab/issues/90 , by deleting files after a run. 
Also shortens the stack output in `toText`. Any consensus issues in the earlier part of the stack will be visible later or sooner, when the stack is shallower again. 
Also added an example to repro the constantinople fork. 