### PR TITLE
Use interal function for adding storage during genesis file creation

### DIFF
--- a/evmlab/genesis.py
+++ b/evmlab/genesis.py
@@ -172,9 +172,8 @@ class Genesis(object):
             "nonce" : account['nonce'],
         }
         if 'storage' in account:
-            self.alloc[account['address'].lower()]['storage'] = {}
-            for key in account['storage']:
-                self.alloc[account['address'].lower()]['storage'][key] = account['storage'][key]
+            for key, value in account['storage'].items():
+                self.addStorage(account['address'], key, value)
 
     def add(self, account): 
             

--- a/tests/test_genesis.py
+++ b/tests/test_genesis.py
@@ -1,0 +1,26 @@
+import unittest
+from evmlab.genesis import Genesis
+
+
+ADDRESS = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+# Greeter
+CODE = "0xFFFFFFFFFFFFFFFFFFF"
+
+class GenesisTest(unittest.TestCase):
+    def test_uneven_storage(self):
+        g = Genesis()
+        
+        storage = {
+            "0x00": "0x692a",
+            "0x1": "0x4",
+        }
+        g.addPrestateAccount({'code': CODE, 'balance': "0x00", "nonce":"0x01",
+            "address":ADDRESS, "storage": storage})
+
+        correct_storage = {
+                '0x0000000000000000000000000000000000000000000000000000000000000000':
+                '0x000000000000000000000000000000000000000000000000000000000000692a',
+                '0x0000000000000000000000000000000000000000000000000000000000000001':
+                '0x0000000000000000000000000000000000000000000000000000000000000004',
+        }
+        self.assertDictEqual(g.alloc[ADDRESS.lower()]["storage"], correct_storage)


### PR DESCRIPTION
When adding accounts with storage to a genesis file, some vms expect padded values (e.g., geth does, parity does not). At the moment the ```addPrestateAccount``` function does not perform such padding.

This pr changes the behaviour for adding storage values to use the internal ```addStorage``` function which performs padding. Additionally I added a simple unit test.