### PR TITLE
create consistent StateTestTemplate object instead of dict

### DIFF
--- a/evmlab/tools/statetests/randomtest.py
+++ b/evmlab/tools/statetests/randomtest.py
@@ -20,7 +20,7 @@ def walk_iterable(d, prn):
             elif isinstance(v, list):
                 walk_iterable(d=v, prn=prn)
             else:
-                prn(d, k)  # provide dict and key for substitutaion
+                prn(d, k)  # provide dict and key for substitution
     elif isinstance(d, list):
         for k, v in enumerate(d):
             if isinstance(v, dict):
@@ -28,7 +28,7 @@ def walk_iterable(d, prn):
             elif isinstance(v, list):
                 walk_iterable(d=v, prn=prn)
             else:
-                prn(d, k)  # provide dict and key for substitutaion
+                prn(d, k)  # provide dict and key for substitution
 
 
 def get_classes():

--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -24,9 +24,9 @@ except ImportError as ie:
     logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
     logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
 
-#try:
-#    from .codesmart2 import RndCode2
-#    RndCode = RndCode2
-#except ImportError as ie:
-#    logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
-#    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
+try:
+    from .codesmart2 import RndCode2
+    #RndCode = RndCode2
+except ImportError as ie:
+    logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)
+    logging.warning("----> Falling back to Random Code Generation based on byte distribution!")

--- a/evmlab/tools/statetests/rndval/__init__.py
+++ b/evmlab/tools/statetests/rndval/__init__.py
@@ -25,7 +25,7 @@ except ImportError as ie:
     logging.warning("----> Falling back to Random Code Generation based on byte distribution!")
 
 try:
-    from .codesmart2 import RndCode2
+    from .codesmart2 import RndCodeSmart2
     #RndCode = RndCode2
 except ImportError as ie:
     logging.warning("[!! Exception] Failed to Import RndCodeInstr() - %r"%ie)

--- a/evmlab/tools/statetests/rndval/base.py
+++ b/evmlab/tools/statetests/rndval/base.py
@@ -42,8 +42,9 @@ class _RndBase(object):
 
     QUOTE = "'"
 
-    def __init__(self, seed=None):
+    def __init__(self, seed=None, _config=None):
         self.seed = seed
+        self._config = _config
 
     def __str__(self):
         # for json serialization

--- a/evmlab/tools/statetests/rndval/code.py
+++ b/evmlab/tools/statetests/rndval/code.py
@@ -9,12 +9,27 @@ class _RndCodeBase(_RndBase):
 
     FLAG_FOCUS_CONSTANTINOPLE = 1
 
-    def __init__(self, seed=None, length=None, prefix="0x", fill_arguments=True, flags=[]):
-        super().__init__(seed=seed)
+    def __init__(self, seed=None, length=None, prefix="0x", fill_arguments=True, flags=[], _config=None):
+        super().__init__(seed=seed, _config=_config)
         self.length = length
         self.prefix = prefix
         self.fill_arguments = fill_arguments
         self.flags = set(flags)
+
+    def _config_getint(self, key, default=None):
+        if not self._config:
+            return default
+        return self._config.getint(key, default)
+
+    def _config_get(self, key, default=None):
+        if not self._config:
+            return default
+        return self._config.get(key, default)
+
+    def _config_getbool(self, key, default=None):
+        if not self._config:
+            return default
+        return self._config.getboolean(key, default)
 
 
 class RndCodeBytes(_RndCodeBase):

--- a/evmlab/tools/statetests/rndval/codesmart.py
+++ b/evmlab/tools/statetests/rndval/codesmart.py
@@ -158,7 +158,6 @@ class RndCodeInstr(_RndCodeBase):
         return address
 
     def _fill_arguments(self, instructions):
-        probabilities = {'smartCodeProbability': 99}
         #https://github.com/ethereum/testeth/blob/7cbbb6fed4941420fbae738828fa1339c990e3d3/test/tools/fuzzTesting/fuzzHelper.cpp#L391
         def create_push_for_data(data):
             # expect bytes but silently convert int2bytes
@@ -171,7 +170,7 @@ class RndCodeInstr(_RndCodeBase):
 
         for instr in instructions:
             args_filled = False
-            if self.randomPercent() < probabilities["smartCodeProbability"]:
+            if self.randomPercent() < self._config_getint("engine.RndCodeInstr.smartCodeProbability.p", 990)/10:
                 # push arguments code
                 if instr.name.startswith("PUSH"):
                     instr.randomize_operand()

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -119,7 +119,11 @@ class RndCodeSmart2(_RndCodeBase):
     # analyzed based on statedump.json
 
     def generate(self, length=None):
-        distribution = evmcodegen.distributions.EVM_CATEGORY  # override this in here to adjust weights
+        # override this in here to adjust weights
+        distribution = getattr(evmcodegen.distributions,
+                                self._config_get("engine.RndCodeSmart2.distribution", ""),
+                                evmcodegen.distributions.EVM_CATEGORY)
+
         if length is None:
             length = distribution.avg
         generator = evmcodegen.generators.distribution.GaussDistrCodeGen(distribution=distribution)

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -110,7 +110,7 @@ class BytecodeMutators:
         return bytecode
 
 
-class RndCode2(_RndCodeBase):
+class RndCodeSmart2(_RndCodeBase):
     """
     Random bytecode based on stat spread of instructions
     """

--- a/evmlab/tools/statetests/rndval/codesmart2.py
+++ b/evmlab/tools/statetests/rndval/codesmart2.py
@@ -137,6 +137,9 @@ class RndCode2(_RndCodeBase):
             # balance it?
             evmcode.fix_stack_balance()
 
+        ##### store some metrix
+        self._addresses_seen = evmcode._addresses_seen
+
         ######## mutation ########
 
         # mutate instructions in 1% of cases - likely invalid code

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -218,6 +218,10 @@ class StateTestTemplate(object):
     def json(self):
         return json.dumps(self.__dict__, cls=randomtest.RandomTestsJsonEncoder)
 
+    def fill(self):
+        # todo: performance
+        return json.loads(self.json())
+
 
 if __name__=="__main__":
     st = StateTestTemplate(nonce="0x1d",

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -110,7 +110,7 @@ class StateTest(object):
         # todo: hacky hack
         try:
             for addr in self.pick_codegen("smart")._addresses_seen:
-                self._autofill_prestate(binascii.hexlify(addr).decode("utf-8"))
+                self._autofill_prestate(addr)
         except AttributeError as ae:
             pass  # addresses_seen is not available
 

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -76,12 +76,12 @@ class StateTest(object):
         return {hx:hx for hx in rnd_vals}
 
 
-    def _autofill_prestates_from_transaction(self):
-        if self.transaction.to in self.pre:
+    def _autofill_prestates_from_transaction(self, tx):
+        if tx.to in self.pre:
             # already there
             return self
 
-        self._autofill_prestate(self.transaction.to)
+        self._autofill_prestate(tx.to)
 
         return self
 
@@ -115,11 +115,13 @@ class StateTest(object):
 
 
     def _build(self):
-        if isinstance(self.transaction.to, rndval.RndAddress):
-            self.transaction.to = self.transaction.to.generate()
+        # clone the tx namespace and replace the generator with a concrete value (we can then refer to that value later)
+        tx = SimpleNamespace(**self.transaction.__dict__)
+        if isinstance(tx.to, rndval.RndAddress):
+            tx.to = tx.to.generate()
 
         if self._fill_prestate_for_tx_to:
-            self._autofill_prestates_from_transaction()
+            self._autofill_prestates_from_transaction(tx)
 
         if self._fill_prestate_for_args:
             self._autofill_prestates_from_stack_arguments()
@@ -129,7 +131,7 @@ class StateTest(object):
                        "env": self.env.__dict__,
                        "post": self.post,
                        "pre": {address:a.__dict__ for address,a in self.pre.items()},
-                       "transaction": self.transaction.__dict__}}
+                       "transaction": tx.__dict__}}
 
     @property
     def info(self):

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -1,0 +1,221 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author : <github.com/tintinweb>
+from evmlab.tools.statetests import rndval
+from types import SimpleNamespace
+from evmlab.tools.statetests.rndval.base import WeightedRandomizer
+import random
+import binascii
+
+
+class Account(object):
+
+    def __init__(self, address, balance=None, code=None, nonce=None, storage=None):
+        self.address = address
+        self.balance = balance if balance is not None else rndval.RndHexInt(_min=2**24-1)
+        self.code = code if code is not None else ''
+        self.nonce = nonce
+        self.storage = storage if storage is not None else {}
+
+    @property
+    def __dict__(self):
+        return {"balance": self.balance,
+                "code": self.code,
+                "nonce": self.nonce,
+                "storage": self.storage}
+
+
+class StateTest(object):
+
+    def __init__(self, nonce=None, codegenerators={}, codegenerators_weights={}, datalength=None, fill_prestate_for_tx_to=True, fill_prestate_for_args=False):
+        ### global settings
+        self._nonce = nonce if nonce is not None else str(rndval.RndV())
+        self._codegenerators = codegenerators  # available code generators
+        self._codegenerators_weighted = WeightedRandomizer({obj:codegenerators_weights[name] for name,obj in codegenerators.items()})
+        self._datalength = datalength
+        self._fill_prestate_for_tx_to = fill_prestate_for_tx_to
+        self._fill_prestate_for_args = fill_prestate_for_args
+
+        ### info
+        self._info = SimpleNamespace(fuzzer="evmlab",
+                                     comment="evmlab",
+                                     filledwith="evmlab randomfuzz")
+
+        ### env
+        self._env = SimpleNamespace(currentCoinbase=rndval.RndAddress(),
+                                    currentDifficulty="0x20000",
+                                    currentGasLimit="0x1312D00",
+                                    currentNumber="1",
+                                    currentTimestamp="1000",
+                                    previousHash=rndval.RndHash32())
+
+        ### post
+        self._post = {"Byzantium": [
+                            {  # dummy to make statetests happy
+                                "hash": "0x00000000000000000000000000000000000000000000000000000000deadc0de",
+                                "logs": "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+                                "indexes": {"data": 0, "gas": 0, "value": 0}
+                            }]
+                     }
+
+        ### pre
+        self._pre = {}
+
+        ### transaction
+        self._transaction = SimpleNamespace(secretKey="0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+                                            data=[self.pick_codegen("bytes").generate(length=self._datalength)],
+                                            gasLimit=[rndval.RndTransactionGasLimit(_min=34 * 14000)],
+                                            gasPrice= rndval.RndGasPrice(),
+                                            nonce=self._nonce,
+                                            to=rndval.RndDestAddressOrZero(),
+                                            value=rndval.RndHexInt(_min=0, _max=max(0, 2**24)))
+
+    def _random_storage(self, _min=0, _max=10):
+        hx = rndval.RndHex32()
+        rnd_vals = (hx.generate() for _ in range(random.randint(_min, _max)))
+        return {hx:hx for hx in rnd_vals}
+
+
+    def _autofill_prestates_from_transaction(self):
+        if self.transaction.to in self.pre:
+            # already there
+            return self
+
+        self._autofill_prestate(self.transaction.to)
+
+        return self
+
+    def _autofill_prestate(self, address):
+        if address in self.pre:
+            # already there
+            return self
+
+        if address.startswith("0000000000000000000000000000000000000"):  #skipped the first 3 bytes
+            # appears to be an immediate CREATE, no need to push any prestates here
+            # todo: what about the other PRECOMPILED addresses? I guess it is save to skip prestates for them as they're precompiled anyway
+            return self
+        # not a precompiled address?
+        # add a random prestate for the address we interact with in the tx
+        ### random code
+        ### same nonce
+        ### random balance
+        ### random storage
+
+        self.add_prestate(address="0x%s"%address.replace("0x",""), storage=self._random_storage(_min=0, _max=2))
+
+        return self
+
+    def _autofill_prestates_from_stack_arguments(self):
+        # todo: hacky hack
+        try:
+            for addr in self.pick_codegen("smart")._addresses_seen:
+                self._autofill_prestate(binascii.hexlify(addr).decode("utf-8"))
+        except AttributeError as ae:
+            pass  # addresses_seen is not available
+
+
+    def _build(self):
+        if isinstance(self.transaction.to, rndval.RndAddress):
+            self.transaction.to = self.transaction.to.generate()
+
+        if self._fill_prestate_for_tx_to:
+            self._autofill_prestates_from_transaction()
+
+        if self._fill_prestate_for_args:
+            self._autofill_prestates_from_stack_arguments()
+
+        return {"randomStatetest": {
+                       "_info": self.info.__dict__,
+                       "env": self.env.__dict__,
+                       "post": self.post,
+                       "pre": {address:a.__dict__ for address,a in self.pre.items()},
+                       "transaction": self.transaction.__dict__}}
+
+    @property
+    def info(self):
+        return self._info
+
+    @property
+    def env(self):
+        return self._env
+
+    @property
+    def post(self):
+        return self._post
+
+    @property
+    def pre(self):
+        return self._pre
+
+    @pre.setter
+    def pre(self, accounts):
+        self._pre = accounts
+
+    @property
+    def transaction(self):
+        return self._transaction
+
+    @transaction.setter
+    def transaction(self, transaction):
+        self._transaction = transaction
+
+    def add_prestate(self, address, balance=None, code=None, nonce=None, storage=None):
+        acc = Account(address=address,
+                      balance=balance,
+                      code=code if code is not None else self.pick_codegen().generate(),
+                      nonce=nonce if nonce is not None else self._nonce,  # use global nonce if not explicitly set
+                      storage=storage)
+        self.pre[acc.address] = acc
+
+    def pick_codegen(self, name=None):
+        if name:
+            return self._codegenerators[name]
+        return self._codegenerators_weighted.random()
+
+    @property
+    def __dict__(self):
+        return self._build()
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def __iter__(self):
+        yield self._build()
+
+
+if __name__=="__main__":
+    st = StateTest(nonce="0x1d",
+                   codegenerators={"bytes":rndval.RndCodeBytes(),
+                                   "instr":rndval.RndCodeInstr(),
+                                   "smart":rndval.RndCode2()},
+                   codegenerators_weights={"bytes":20,
+                                           "instr":20,
+                                           "smart":60},
+                   fill_prestate_for_args=True,
+                   fill_prestate_for_tx_to=True)
+    st.info.fuzzer = "evmlab tin"
+
+    #st.env.currentCoinbase = rndval.RndDestAddress()
+    #st.env.previousHash = rndval.RndHash32()
+
+    #st.add_prestate(address="ffffffffffffffffffffffffffffffffffffffff")
+    #st.add_prestate(address="1000000000000000000000000000000000000000")
+    #st.add_prestate(address="b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    #st.add_prestate(address="c94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    #st.add_prestate(address="d94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    #st.add_prestate(address="a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+
+    import pprint
+
+    pprint.pprint(st.__dict__)
+    pprint.pprint(st.__dict__)
+
+
+
+
+
+
+

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -28,9 +28,10 @@ class Account(object):
 
 class StateTestTemplate(object):
 
-    def __init__(self, nonce=None, codegenerators={}, datalength=None, fill_prestate_for_tx_to=True, fill_prestate_for_args=False):
+    def __init__(self, nonce=None, codegenerators={}, datalength=None, fill_prestate_for_tx_to=True, fill_prestate_for_args=False, _config=None):
         ### global settings
         self._nonce = nonce if nonce is not None else str(rndval.RndV())
+        self._config = _config
 
         ### set by setters below
         self._codegenerators = None  # default
@@ -147,7 +148,7 @@ class StateTestTemplate(object):
 
     @codegens.setter
     def codegens(self, weighted_codegens):
-        self._codegenerators = {engine: engine() for engine in
+        self._codegenerators = {engine: engine(_config=self._config) for engine in
                                 weighted_codegens.keys()}  # instantiate available code generators
         self._codegenerators_weighted = WeightedRandomizer(
             {self._codegenerators[engine]: weight for engine, weight in weighted_codegens.items()})  #
@@ -215,7 +216,7 @@ class StateTestTemplate(object):
         yield self._build()
 
     def json(self):
-        return json.dumps(st.__dict__, cls=randomtest.RandomTestsJsonEncoder)
+        return json.dumps(self.__dict__, cls=randomtest.RandomTestsJsonEncoder)
 
 
 if __name__=="__main__":

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -90,9 +90,8 @@ class StateTest(object):
             # already there
             return self
 
-        if address.startswith("0000000000000000000000000000000000000"):  #skipped the first 3 bytes
-            # appears to be an immediate CREATE, no need to push any prestates here
-            # todo: what about the other PRECOMPILED addresses? I guess it is save to skip prestates for them as they're precompiled anyway
+        if address.replace("0x","") not in rndval.RndAddress.addresses[rndval.RndAddressType.SENDING_ACCOUNT]+rndval.RndAddress.addresses[rndval.RndAddressType.STATE_ACCOUNT]:
+            # skip non state accounts
             return self
         # not a precompiled address?
         # add a random prestate for the address we interact with in the tx
@@ -101,7 +100,9 @@ class StateTest(object):
         ### random balance
         ### random storage
 
-        self.add_prestate(address="0x%s"%address.replace("0x",""), storage=self._random_storage(_min=0, _max=2))
+        self.add_prestate(address="0x%s"%address.replace("0x",""),
+                          code=self.pick_codegen().generate(length=random.randint(0,500)),  # limit length, main code is in first prestate
+                          storage=self._random_storage(_min=0, _max=2))
 
         return self
 

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -68,7 +68,7 @@ class StateTest(object):
                                             gasPrice= rndval.RndGasPrice(),
                                             nonce=self._nonce,
                                             to=rndval.RndDestAddressOrZero(),
-                                            value=rndval.RndHexInt(_min=0, _max=max(0, 2**24)))
+                                            value=[rndval.RndHexInt(_min=0, _max=max(0, 2**24))])
 
     def _random_storage(self, _min=0, _max=10):
         hx = rndval.RndHex32()

--- a/statetests.ini
+++ b/statetests.ini
@@ -42,30 +42,37 @@ engine.RndCodeSmart2.weight = 70
 
 # [[RndCodeSmart2]]
 # special settings for
-#engine.RndCodeSmart2.min_gas = 100
+engine.RndCodeSmart2.min_gas = 100
 #engine.RndCodeSmart2.generator = RndCodeGenGauss
+
+# fix code length to a specific value. otherwise take random length value from distribution
 #engine.RndCodeSmart2.length = 800
 
-## fixes likelyhood  (0 = disabled)
-engine.RndCodeSmart2.fixes.fix_stack_arguments.p = 995 # of 1000
-engine.RndCodeSmart2.fixes.fix_jumps.p = 995
+## probabilities
+# 0 = disabled
+# values are x/1000. i.e. 99 ^== 9.9 %
+engine.RndCodeSmart2.fixes.fix_stack_arguments.p = 995
 engine.RndCodeSmart2.fixes.fix_stack_balance.p = 950
+# not yet configurable
+# engine.RndCodeSmart2.fixes.fix_jumps.p = 995
 
 ## Mutation probabilities
 ### instruction mutator
 engine.RndCodeSmart2.mutate.instructions.p = 10
-engine.RndCodeSmart2.mutate.instructions.max_amount = 3 # random(1, max_amount)
+# random(1, max_amount)
+engine.RndCodeSmart2.mutate.instructions.max_amount = 3
 
 engine.RndCodeSmart2.mutate.instructions.randomize_operand.weight = 60
 engine.RndCodeSmart2.mutate.instructions.drop_item.weight = 10
 engine.RndCodeSmart2.mutate.instructions.dup_instruction.weight = 20
-engine.RndCodeSmart2.mutate.insert_random_instructions.weight = 10
+engine.RndCodeSmart2.mutate.instructions.insert_random_instructions.weight = 10
 
 # byte mutator
 engine.RndCodeSmart2.mutate.bytecode.p = 1
-engine.RndCodeSmart2.mutate.bytecode.max_amount = 3 # random(1, max_amount)
+# random(1, max_amount)
+engine.RndCodeSmart2.mutate.bytecode.max_amount = 3
 
 engine.RndCodeSmart2.mutate.bytecode.randomize_operand.weight = 50
-engine.RndCodeSmart2.mutate.bytecode.drop_item.weight = 10
-engine.RndCodeSmart2.mutate.bytecode.dup_instruction.weight = 20
-engine.RndCodeSmart2.mutate.bytecode.weight = 20
+engine.RndCodeSmart2.mutate.bytecode.insert_random_bytes.weight = 10
+engine.RndCodeSmart2.mutate.bytecode.drop_byte.weight = 20
+engine.RndCodeSmart2.mutate.bytecode.switch_random.weight = 20

--- a/statetests.ini
+++ b/statetests.ini
@@ -28,3 +28,44 @@ testeth.docker_name   = holiman/testeth
 
 #testeth.docker_name = cdetrio/testeth
 
+
+[codegen]
+# Codegenerator settings
+engine.RndCodeBytes.enabled = true
+engine.RndCodeInstr.enabled = true
+engine.RndCodeSmart2.enabled = true
+
+## probabilities for each codegen to be chosen
+engine.RndCodeBytes.weight = 5
+engine.RndCodeInstr.weight = 25
+engine.RndCodeSmart2.weight = 70
+
+# [[RndCodeSmart2]]
+# special settings for
+#engine.RndCodeSmart2.min_gas = 100
+#engine.RndCodeSmart2.generator = RndCodeGenGauss
+#engine.RndCodeSmart2.length = 800
+
+## fixes likelyhood  (0 = disabled)
+engine.RndCodeSmart2.fixes.fix_stack_arguments.p = 995 # of 1000
+engine.RndCodeSmart2.fixes.fix_jumps.p = 995
+engine.RndCodeSmart2.fixes.fix_stack_balance.p = 950
+
+## Mutation probabilities
+### instruction mutator
+engine.RndCodeSmart2.mutate.instructions.p = 10
+engine.RndCodeSmart2.mutate.instructions.max_amount = 3 # random(1, max_amount)
+
+engine.RndCodeSmart2.mutate.instructions.randomize_operand.weight = 60
+engine.RndCodeSmart2.mutate.instructions.drop_item.weight = 10
+engine.RndCodeSmart2.mutate.instructions.dup_instruction.weight = 20
+engine.RndCodeSmart2.mutate.insert_random_instructions.weight = 10
+
+# byte mutator
+engine.RndCodeSmart2.mutate.bytecode.p = 1
+engine.RndCodeSmart2.mutate.bytecode.max_amount = 3 # random(1, max_amount)
+
+engine.RndCodeSmart2.mutate.bytecode.randomize_operand.weight = 50
+engine.RndCodeSmart2.mutate.bytecode.drop_item.weight = 10
+engine.RndCodeSmart2.mutate.bytecode.dup_instruction.weight = 20
+engine.RndCodeSmart2.mutate.bytecode.weight = 20

--- a/statetests.ini
+++ b/statetests.ini
@@ -40,6 +40,10 @@ engine.RndCodeBytes.weight = 5
 engine.RndCodeInstr.weight = 25
 engine.RndCodeSmart2.weight = 70
 
+# [[RndCodeInstr]]
+# 99.0%
+engine.RndCodeInstr.smartCodeProbability.p = 990
+
 # [[RndCodeSmart2]]
 # special settings for
 engine.RndCodeSmart2.min_gas = 100

--- a/statetests.ini
+++ b/statetests.ini
@@ -48,6 +48,7 @@ engine.RndCodeInstr.smartCodeProbability.p = 990
 # special settings for
 engine.RndCodeSmart2.min_gas = 100
 #engine.RndCodeSmart2.generator = RndCodeGenGauss
+#engine.RndCodeSmart2.distribution = EVM_CATEGORY
 
 # fix code length to a specific value. otherwise take random length value from distribution
 #engine.RndCodeSmart2.length = 800

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -283,8 +283,9 @@ class TestExecutor(object):
 
         if reporting:
             # Do some reporting
-            logger.info("Fails: {}, Pass: {}, #test {} speed: {:f} tests/s".format(
-                self.numFails(), self.numPass(), self.numTotals(), self.testsPerSecond()
+            logger.info("Fails: {}, Pass: {}, #test {} speed: {:f} tests/s (trace_len avg: {}, max: {})".format(
+                self.numFails(), self.numPass(), self.numTotals(), self.testsPerSecond(),
+                self._fuzzer._total_trace_len / self._fuzzer._num_traces_processed, self._fuzzer._max_trace_len
             ))
 
     def startFuzzing(self):
@@ -387,6 +388,7 @@ class Fuzzer(object):
 
         self._num_traces_processed = 0
         self._total_trace_len = 0
+        self._max_trace_len = 0
 
         self._dockerclient = docker.from_env()
 
@@ -587,9 +589,10 @@ class Fuzzer(object):
             tracelen = len(canon_trace)
             self._num_traces_processed += 1
             self._total_trace_len += tracelen
+            self._max_trace_len = max(self._max_trace_len, tracelen)
             t2 = time.time()
-            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms  (avg. trace length for all traces: %d)"
-                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1), self._total_trace_len/self._num_traces_processed))
+            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms "
+                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))
 
         # print(stats)
         # print(canon_steps)

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -462,7 +462,19 @@ class Fuzzer(object):
         """
 
         from evmlab.tools.statetests import templates
-        from evmlab.tools.statetests import randomtest
+        from evmlab.tools.statetests import randomtest, statetests
+
+        st = statetests.StateTest(nonce="0x1d",
+                       codegenerators={"bytes": statetests.rndval.RndCodeBytes(),
+                                       "instr": statetests.rndval.RndCodeInstr(),
+                                       "smart": statetests.rndval.RndCode2()},
+                       codegenerators_weights={"bytes": 20,
+                                               "instr": 20,
+                                               "smart": 60},
+                       fill_prestate_for_args=True,
+                       fill_prestate_for_tx_to=True)
+        st.info.fuzzer = "evmlab tin"
+        t = st.__dict__
 
         t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
         test = {}

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -469,9 +469,9 @@ class Fuzzer(object):
                        codegenerators={"bytes": statetest.rndval.RndCodeBytes(),
                                        "instr": statetest.rndval.RndCodeInstr(),
                                        "smart": statetest.rndval.RndCode2()},
-                       codegenerators_weights={"bytes": 20,
-                                               "instr": 20,
-                                               "smart": 60},
+                       codegenerators_weights={"bytes": 5,
+                                               "instr": 15,
+                                               "smart": 80},
                        fill_prestate_for_args=True,
                        fill_prestate_for_tx_to=True)
         st.info.fuzzer = "evmlab tin"

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -406,7 +406,7 @@ class Fuzzer(object):
 
         codegens = {}
         for engine in (statetest.rndval.RndCodeBytes, statetest.rndval.RndCodeInstr, statetest.rndval.RndCodeSmart2):
-            if self._config.codegen.get("engine.%s.enabled" % engine.__name__, True):  # is engine enabled?
+            if self._config.codegen.getboolean("engine.%s.enabled" % engine.__name__, True):  # is engine enabled?
                 codegens[engine] = int(self._config.codegen.get("engine.%s.weight" % engine.__name__,
                                                                 "50"))  # create engine/weight mapping
 

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -494,7 +494,8 @@ class Fuzzer(object):
 
         while True:
             #test.update(t)
-            test_obj = json.loads(self.statetest_template.json())   # generates a new filled dict based on the template specification
+            #test_obj = json.loads(self.statetest_template.json())   # generates a new filled dict based on the template specification
+            test_obj = self.statetest_template.fill()
             s = StateTest(test_obj, counter, config=self._config)
             counter = counter + 1
             yield s

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -462,27 +462,28 @@ class Fuzzer(object):
         """
 
         from evmlab.tools.statetests import templates
-        from evmlab.tools.statetests import randomtest, statetests
+        from evmlab.tools.statetests import randomtest
+        from evmlab.tools.statetests.templates import statetest
 
-        st = statetests.StateTest(nonce="0x1d",
-                       codegenerators={"bytes": statetests.rndval.RndCodeBytes(),
-                                       "instr": statetests.rndval.RndCodeInstr(),
-                                       "smart": statetests.rndval.RndCode2()},
+        st = statetest.StateTest(nonce="0x1d",
+                       codegenerators={"bytes": statetest.rndval.RndCodeBytes(),
+                                       "instr": statetest.rndval.RndCodeInstr(),
+                                       "smart": statetest.rndval.RndCode2()},
                        codegenerators_weights={"bytes": 20,
                                                "instr": 20,
                                                "smart": 60},
                        fill_prestate_for_args=True,
                        fill_prestate_for_tx_to=True)
         st.info.fuzzer = "evmlab tin"
-        t = st.__dict__
 
-        t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
+
+        #t = templates.new(templates.object_based.TEMPLATE_RandomStateTest)
         test = {}
         counter = 0
 
         while True:
-            test.update(t)
-            test_obj = json.loads(json.dumps(t, cls=randomtest.RandomTestsJsonEncoder))
+            #test.update(t)
+            test_obj = json.loads(json.dumps(st.__dict__, cls=randomtest.RandomTestsJsonEncoder))
             s = StateTest(test_obj, counter, config=self._config)
             counter = counter + 1
             yield s

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -283,9 +283,9 @@ class TestExecutor(object):
 
         if reporting:
             # Do some reporting
-            logger.info("Fails: {}, Pass: {}, #test {} speed: {:f} tests/s (trace_len avg: {}, max: {})".format(
+            logger.info("Fails: {}, Pass: {}, #test {} speed: {:f} tests/s (trace_len avg: {}, max: {}, zero_trace_rate: {})".format(
                 self.numFails(), self.numPass(), self.numTotals(), self.testsPerSecond(),
-                self._fuzzer._total_trace_len / self._fuzzer._num_traces_processed, self._fuzzer._max_trace_len
+                self._fuzzer._total_trace_len / self._fuzzer._num_traces_processed, self._fuzzer._max_trace_len, self._fuzzer._num_zero_traces/self._fuzzer._num_traces_processed
             ))
 
     def startFuzzing(self):
@@ -389,6 +389,7 @@ class Fuzzer(object):
         self._num_traces_processed = 0
         self._total_trace_len = 0
         self._max_trace_len = 0
+        self._num_zero_traces = 0
 
         self._dockerclient = docker.from_env()
 
@@ -590,6 +591,8 @@ class Fuzzer(object):
             self._num_traces_processed += 1
             self._total_trace_len += tracelen
             self._max_trace_len = max(self._max_trace_len, tracelen)
+            if tracelen==0:
+                self._num_zero_traces += 1
             t2 = time.time()
             logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms "
                         % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -385,6 +385,9 @@ class Fuzzer(object):
     def __init__(self, config=None):
         self._config = config
 
+        self._num_traces_processed = 0
+        self._total_trace_len = 0
+
         self._dockerclient = docker.from_env()
 
         if config.docker_force_update_image is not None:
@@ -582,9 +585,11 @@ class Fuzzer(object):
             stats.stop()
             test.canon_traces.append(canon_trace)
             tracelen = len(canon_trace)
+            self._num_traces_processed += 1
+            self._total_trace_len += tracelen
             t2 = time.time()
-            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms"
-                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))
+            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms  (avg. trace length for all traces: %d)"
+                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1), self._total_trace_len/self._num_traces_processed))
 
         # print(stats)
         # print(canon_steps)


### PR DESCRIPTION
// this is a preparation to make various settings configurable via cmdline/statetests.ini. There's no good way to achieve this using the current dictionary approach. Wit the object we can implement measures that make sure to always create syntactically correct statetests to minimize errors and tune performance

* switch from dictionary based templates to a concrete statetest objects (gives better control over random code genration and allows optimizations for speed, type of code generated, etc)
* track addresses that have been generated and autofill prestates for used state accounts
* collect more stats: avg trace length, max trance length, % of zero length traces
* do not always generate new values (xmas fuzzing)
* we now have easy control over what type of codegenerators to use
* added random storage filling

- [x] rename `StateTest` class in the new object based template as this is conflicting with the fuzzers `StateTest` class

```python
st = StateTestTemplate(nonce="0x1d",
                       codegenerators={rndval.RndCodeBytes: 5,
                                       rndval.RndCodeInstr: 25,
                                       rndval.RndCodeSmart2: 70},
                       fill_prestate_for_args=True,
                       fill_prestate_for_tx_to=True)
st.info.fuzzer = "evmlab tin"

#st.env.currentCoinbase = rndval.RndDestAddress()
#st.env.previousHash = rndval.RndHash32()

#st.add_prestate(address="ffffffffffffffffffffffffffffffffffffffff")
#st.add_prestate(address="1000000000000000000000000000000000000000")
#st.add_prestate(address="b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
#st.add_prestate(address="c94f5374fce5edbc8e2a8697c15331677e6ebf0b")
#st.add_prestate(address="d94f5374fce5edbc8e2a8697c15331677e6ebf0b")
#st.add_prestate(address="a94f5374fce5edbc8e2a8697c15331677e6ebf0b")

import pprint

pprint.pprint(st.__dict__)
pprint.pprint(st.__dict__)
```

some fuzzer run stats (running on a low res vm):

```
Fails: 0, Pass: 783, #test 783 speed: 0.414096 tests/s (trace_len avg: 580.7918263090677, max: 101696, zero_trace_rate: 0.04342273307790549)
```