### PR TITLE
use pooled files, enable create, make old code generator work

### DIFF
--- a/containers/testeth/Dockerfile
+++ b/containers/testeth/Dockerfile
@@ -5,23 +5,18 @@ RUN apk add --no-cache \
         cmake \
         g++ \
         make \
-        linux-headers \
-        leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
-RUN git clone --recursive https://github.com/ethereum/testeth --branch develop --single-branch --depth 1
-RUN sed -i '1s/^/\#define EVM_OPTIMIZE false\n/' testeth/libevm/VMConfig.h
+        linux-headers
+#        leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN git clone --recursive https://github.com/ethereum/aleth --single-branch --depth 1
 RUN mkdir /build
-# See https://github.com/ethereum/cpp-ethereum/issues/4834
-RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF -DEVM_OPTIMIZE=0
-#RUN cd /build && cmake /testeth -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=OFF -DEVM_OPTIMIZE=0 -DSTATIC_LINKING=1
-RUN cmake --version
-RUN cd /build && make -j1 && make install; exit 0
-RUN cd /build && cp -r deps/lib64/libbinaryen.a deps/lib/; cp -r deps/lib64/libmpir.a deps/lib/
-RUN cd /build && make -j1 && make install
-# Install stage 
+RUN cd /build && cmake /aleth -DHUNTER_JOBS_NUMBER=$(nproc)
+RUN cd /build && make -j $(nproc)
+#RUN cd /build && cmake --build .
+
 FROM alpine:latest
 RUN apk add --no-cache \
         libstdc++ \
         leveldb --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/
 COPY --from=builder /build/test/testeth /usr/bin/testeth
 
-#ENTRYPOINT ["/usr/bin/testeth"]
+ENTRYPOINT ["/usr/bin/testeth"]

--- a/evmlab/tools/statetests/rndval/address.py
+++ b/evmlab/tools/statetests/rndval/address.py
@@ -45,7 +45,7 @@ class RndAddress(RndByteSequence):
                                                         "0000000000000000000000000000000000000006",
                                                         "0000000000000000000000000000000000000007",
                                                         "0000000000000000000000000000000000000008"],
-                 RndAddressType.SPECIAL_CREATE: ["0000000000000000000000000000000000000000"]}
+                 RndAddressType.SPECIAL_CREATE: [""]}
 
     def __init__(self, seed=None, length=20, prefix="0x", _types=[RndAddressType.RANDOM]):
         super().__init__(seed=seed, length=length, prefix=prefix)
@@ -94,9 +94,9 @@ class RndAddress(RndByteSequence):
 # transaction would either have to: None, or no to-field present. 
             # CREATE  (if all or create is set)
             #if types_set != set([RndAddressType.PRECOMPILED, RndAddressType.STATE_ACCOUNT]):
-#            if types_set.intersection([RndAddressType.SPECIAL_ALL, RndAddressType.SPECIAL_CREATE]):
-#                if self.randomPercent()<probabilities["emptyAddressProbability"]:
-#                    return ""
+            if types_set.intersection([RndAddressType.SPECIAL_ALL, RndAddressType.SPECIAL_CREATE]):
+                if self.randomPercent()<probabilities["emptyAddressProbability"]:
+                    return ""
 
             # RANDOM
             if self.randomPercent()<probabilities["randomAddressProbability"]:

--- a/evmlab/tools/statetests/rndval/codesmart.py
+++ b/evmlab/tools/statetests/rndval/codesmart.py
@@ -119,40 +119,8 @@ class RndCodeInstr(_RndCodeBase):
         # todo: add gauss histogramm random.randgauss(min,max,avg) - triangle is not really correct here
         length = length or int(random.triangular(self.MIN_CONTRACT_SIZE, 2 * self.AVERAGE_CONTRACT_SIZE + self.MIN_CONTRACT_SIZE))  # use gauss
 
-#        rnd_prolog = WeightedRandomizer(self.LIKELYHOOD_PROLOG_BY_OPCODE_INT)
-#        rnd_epilog = WeightedRandomizer(self.LIKELYHOOD_EPILOG_BY_OPCODE_INT)  # not completely true as this incorps. pro/epilog
-#        rnd_corpus = WeightedRandomizer(self.LIKELYHOOD_BY_OPCODE_INT)
-#       
-        b = []
-        for _ in range(length):
-#            b.append(valid_opcodes[random.randint(0,len(valid_opcodes)-1)])
-            b.append(random.choice(constantinople_skewed_set))
+        b = [random.choice(constantinople_skewed_set) for _ in range(length)]
 
-#        for _ in range(128):
-#            b.append(rnd_prolog.random())
-#            #  hack ahead -
-#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-#                # 10% chance of inserting a constantinople instr
-#                if self.randomPercent() < 5:
-#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
-#
-#        for _ in range(length - 128 * 2):
-#            b.append(rnd_corpus.random())
-#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-#                # 10% chance of inserting a constantinople instr
-#                if self.randomPercent() < 5:
-#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
-#
-#        for _ in range(128):
-#            b.append(rnd_epilog.random())
-#            if self.FLAG_FOCUS_CONSTANTINOPLE in self.flags:
-#                # 10% chance of inserting a constantinople instr
-#                if self.randomPercent() < 5:
-#                    b.append(random.choice([asm_registry.INSTRUCTIONS_BY_NAME["CREATE2"].opcode,
-#                                           asm_registry.INSTRUCTIONS_BY_NAME["EXTCODEHASH"].opcode]))
-#
         return bytes(b)
 
     def _track_address(self, address):

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -34,7 +34,6 @@ class StateTestTemplate(object):
         ### global settings
         self._nonce = nonce if nonce is not None else str(rndval.RndV())
         self._config = _config
-
         ### set by setters below
         self._codegenerators = None  # default
         self._codegenerators_weighted = None
@@ -71,6 +70,12 @@ class StateTestTemplate(object):
 
         ### pre
         self._pre = {}
+        self.add_prestate(address="ffffffffffffffffffffffffffffffffffffffff")
+        self.add_prestate(address="1000000000000000000000000000000000000000")
+        self.add_prestate(address="b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+        self.add_prestate(address="c94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+        self.add_prestate(address="d94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+        self.add_prestate(address="a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
 
         ### transaction
         self._transaction = SimpleNamespace(secretKey="0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",

--- a/evmlab/tools/statetests/templates/statetest.py
+++ b/evmlab/tools/statetests/templates/statetest.py
@@ -9,6 +9,14 @@ from evmlab.tools.statetests.rndval.base import WeightedRandomizer
 
 from evmlab.tools.statetests.rndval import RndCodeBytes
 
+PRECOMPILES = ["0x0000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000002",
+                "0x0000000000000000000000000000000000000003",
+                "0x0000000000000000000000000000000000000004",
+                "0x0000000000000000000000000000000000000005",
+                "0x0000000000000000000000000000000000000006",
+                "0x0000000000000000000000000000000000000007",
+                "0x0000000000000000000000000000000000000008"]
 
 class Account(object):
 
@@ -25,6 +33,7 @@ class Account(object):
                 "code": self.code,
                 "nonce": self.nonce,
                 "storage": self.storage}
+
 
 
 class StateTestTemplate(object):
@@ -70,12 +79,6 @@ class StateTestTemplate(object):
 
         ### pre
         self._pre = {}
-        self.add_prestate(address="ffffffffffffffffffffffffffffffffffffffff")
-        self.add_prestate(address="1000000000000000000000000000000000000000")
-        self.add_prestate(address="b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-        self.add_prestate(address="c94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-        self.add_prestate(address="d94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-        self.add_prestate(address="a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
 
         ### transaction
         self._transaction = SimpleNamespace(secretKey="0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
@@ -269,6 +272,15 @@ class StateTestTemplate(object):
         # todo: performance
         if reset_prestate:
             self.pre = {}
+            # It's better to already have the precompiles there, otherwise it just addres
+            # false positives due to the precompiles not existing in the trie. 
+            # That will lead to consensus errors, but it's not an issue on mainnet, 
+            # because all precompiles already exist there
+            for a in PRECOMPILES:
+                self.pre[a] = Account(address = a, 
+                    balance = "0x01", nonce = "0x00")
+
+
             # will be filled by _build
         return json.loads(self.json())
 

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -535,8 +535,6 @@ class Fuzzer(object):
 
         returns (filename, object)
         """
-        ##### Statetest Template init
-        from evmlab.tools.statetests.templates import statetest
 
         # We'll offload test generation to another thread
         q = queue.Queue(maxsize = 20)
@@ -545,6 +543,14 @@ class Fuzzer(object):
             while True:
                 test_obj = self.statetest_template.fill(reset_prestate=True)
                 s = StateTest(test_obj, counter, config=self._config)
+                ## testing
+                # print(test_obj.keys())
+                # tname = list(test_obj.keys())[0]
+                # for acc in test_obj[tname]["pre"].keys():
+                #     print("account", acc)
+                #     print("account", test_obj[tname]["pre"][acc])
+                # end
+
                 s._filename = fPool.get()
                 s.writeToFile()
                 counter = counter + 1


### PR DESCRIPTION
This PR fixes some bugs I ran into trying to get it to work with the legacy code generators, and also has some improvements. 

* The fuzzer now does not create/delete files all the time , but instead overwrites old files using a pooled approach. 
* The fuzzer now makes testcases that are create-transactions. 
* The spurious failures #102 is fixed, we simply ignore it if it happens. 
* Added back the old prestate accounts, they had gone missing if we weren't using the smart analyzer to figure out which accounts were used. 

@tintinweb I probably screwed up with your code, sorry 