### PR TITLE
Perf/codegen for prestates

### DIFF
--- a/statetests.ini
+++ b/statetests.ini
@@ -46,6 +46,13 @@ info.comment = evmlab statetest
 #prestate.random.code.length.min = 50
 #prestate.random.code.length.max = 500
 
+## performance: prestate regeneration behavior
+# renew.every.x.rounds  ... 1 = always
+# renew.limit.per.round ... max number of existing prestates to regenerate in a round. 0 = all
+#prestate.txto.renew.every.x.rounds = 1
+#prestate.other.renew.every.x.rounds = 1
+#prestate.other.renew.limit.per.round = 0
+
 # transaction gas limit
 #transaction.gaslimit.random.min = 476000
 #transaction.value.random.min = 0

--- a/statetests.ini
+++ b/statetests.ini
@@ -69,7 +69,7 @@ engine.RndCodeSmart2.enabled = true
 ## probabilities for each codegen to be chosen
 engine.RndCodeBytes.weight = 5
 engine.RndCodeInstr.weight = 25
-engine.RndCodeSmart2.weight = 75
+engine.RndCodeSmart2.weight = 70
 
 # [[RndCodeInstr]]
 # 99.0%

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -330,7 +330,9 @@ class TestExecutor(object):
             ))
 
     def startFuzzing(self):
+        print_stats_every_x_seconds = 90
         self.stats["start_time"] = time.time()
+        next_stats_print = self.stats["start_time"] + print_stats_every_x_seconds
         # This is the max cap of paralellism, it's just to prevent
         # things going out of hand if tests start piling up
         # We don't expect to actually reach it
@@ -393,6 +395,15 @@ class TestExecutor(object):
                     logger.info("All procs finished for test %s" % test.id)
                     self.stats["num_active_tests"] = self.stats["num_active_tests"] - 1
                     self.postprocess_test(test, reporting=self._fuzzer._config.enable_reporting)
+
+            if time.time()> next_stats_print:
+                logger.info("=" * 25)
+                logger.info("current status: %r"%self.status())
+                logger.info("tracelength distribution: %r" % dict(collections.Counter(self.traceLengths).most_common(10)))
+                logger.info("=" * 25)
+                next_stats_print = time.time() + print_stats_every_x_seconds
+
+
 
     def dry_run(self):
         tstart = time.time()

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -411,7 +411,7 @@ class TestExecutor(object):
             if time.time()> next_stats_print:
                 logger.info("=" * 25)
                 logger.info("current status: %r"%self.status())
-                logger.info("tracelength distribution: %r" % dict(collections.Counter(self.traceLengths).most_common(10)))
+                logger.info("tracelength distribution (top 10): %r" % dict(collections.Counter(self.traceLengths).most_common(10)))
                 logger.info("=" * 25)
                 next_stats_print = time.time() + print_stats_every_x_seconds
 
@@ -858,7 +858,7 @@ def configFuzzer():
                         help="Benchmark test generation (default: False)")
 
     grp_artefacts = parser.add_argument_group('Configure Output Artefacts and Reporting')
-    grp_artefacts.add_argument("-x", "--force-save", default=None, action="store_true",
+    grp_artefacts.add_argument("-x", "--preserve-files", default=None, action="store_true",
                                help="Keep tracefiles/logs/testfiles for non-failing testcases (watch disk space!) (default: False)")
     grp_artefacts.add_argument("-r", "--enable-reporting", default=None, action="store_true",
                                help="Output testrun statistics (num of passes/fails and speed (default: False)")

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -703,8 +703,9 @@ class Fuzzer(object):
             if tracelen==0:
                 self._num_zero_traces += 1
             t2 = time.time()
-            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms "
-                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1)))
+            logger.info("Processed %s steps for %s on test %s, pTime:%.02f ms (depth: %s, ConstantinopleOps: %s)"
+                        % (tracelen, client_name, test.identifier, 1000 * (t2 - t1),
+                        stats.result().get("maxDepth","nA"), stats.result().get("constatinopleOps","nA")))
 
         # print(stats)
         # print(canon_steps)

--- a/utilities/fuzzer.py
+++ b/utilities/fuzzer.py
@@ -92,6 +92,18 @@ class Config(object):
             if value is not None:
                 self._config.set(uname, arg, str(value))
 
+        for override in self.cmdline_args.set_config:
+            if "=" not in override:
+                logger.warning("skipping config override (format error): %s"%override)
+                continue
+            key, value = override.strip().split("=",1)
+            section, key = key.strip().split(".",1)
+
+            logger.info("overriding: [%s] %s=%s"%(section, key,value))
+            self._config.set(section.strip(), key.strip(), value.strip())
+
+
+
         self.force_save = self._config.get(uname, 'force_save', fallback=False)
         self.enable_reporting = self._config.get(uname, 'enable_reporting', fallback=False)
         self.docker_force_update_image = self._config.get(uname, 'docker_force_update_image', fallback=None)
@@ -839,6 +851,7 @@ def configFuzzer():
     # <required> configuration file: statetests.ini
     parser.add_argument("-c", "--configfile", default="statetests.ini", required=True,
                         help="path to configuration file (default: statetests.ini)")
+    parser.add_argument("-s", "--set-config", default=[], nargs='*', help="override settings in ini as <section>.<value>=<value>")
     parser.add_argument("-D", "--dry-run", default=False, action="store_true",
                         help="Simulate and print the output instead of running it with the docker backend (default: False)")
     parser.add_argument("-B", "--benchmark", default=False, action="store_true",


### PR DESCRIPTION
* performance settings to control the renewal of prestates for every filler round - idea is to not always have to generate code for all prestates that we've observed as we might not even call them. this just adds extra time to generating code. with the following settings we can tweak the prestate renewal behavior (non-existing addresses are added anyway)
  * configure if you want to regenerate the tx.to prestate everytime invoking `fill()`
  * configure if you want to regenerate other prestates everytime invoking `fill()`
  * configure the max amount of other (not tx.to) prestates to regenerate in a `fill()` found
* precompiles can now be imported by calling `statetesttemplate.add_precomipled_prestates()`
* added stats to console output (every 90sec by default)
  * general stats
  * tracelen distribution  - to detect codegeneration issues
* added `--set-config <section>.<key>=<value>` to generically override ini settings from cmdline

defaults as comments in `statetests.ini`
```
## performance: prestate regeneration behavior
# renew.every.x.rounds  ... 1 = always
# renew.limit.per.round ... max number of existing prestates to regenerate in a round. 0 = all
#prestate.txto.renew.every.x.rounds = 1
#prestate.other.renew.every.x.rounds = 1
#prestate.other.renew.limit.per.round = 0
```

e.g. set `prestate.other.renew.limit.per.round = 2` to only update up to 2 *existing* prestates each filling round.

```
#> python utilities/fuzzer.py -c statetests.ini --enable-reporting --set-config statetest.prestate.other.renew.limit.per.round=2
```